### PR TITLE
Nifty hack to convieniently specify non relative paths in application

### DIFF
--- a/app/auth.js
+++ b/app/auth.js
@@ -1,9 +1,9 @@
 import passport from 'passport';
 import { Strategy as GitHubStrategy } from 'passport-github';
 
-import app from './index.js';
-import { User } from './models/user';
-const CONFIG = require('../config.json');
+import app from 'houston/app';
+import { User } from 'houston/app/models/user';
+import CONFIG from 'houston/config.json';
 
 
 // TODO: Serialize User for sessions

--- a/app/dashboard.js
+++ b/app/dashboard.js
@@ -2,8 +2,8 @@ import Hubkit from 'hubkit';
 import Promise from 'bluebird';
 import ini from 'ini';
 
-import app from './index.js';
-import { loggedIn } from './auth.js';
+import app from 'houston/app';
+import { loggedIn } from 'houston/app/auth.js';
 
 app.get('/dashboard', loggedIn, (req, res, next) => {
 

--- a/app/home.js
+++ b/app/home.js
@@ -1,4 +1,4 @@
-import app from './index.js';
+import app from 'houston/app';
 
 
 /* GET home page. */

--- a/app/index.js
+++ b/app/index.js
@@ -9,16 +9,16 @@ import session from 'express-session';
 // TODO: Not sure how to express (ha, pun) this idiom with ES6 modules
 let MongoStore = require('connect-mongo')(session);
 
-import mongooseConnection from './mongodb';
+import mongooseConnection from 'houston/app/mongodb';
 
-const CONFIG = require('../config.json');
+const CONFIG = require('houston/config.json');
 
 // Initialize Application
 let app = express();
 export default app;
 
 // Setup Handlebars Templates
-import * as HandlebarHelpers from './handlebars-helpers';
+import * as HandlebarHelpers from 'houston/app/handlebars-helpers';
 app.engine('handlebars', exphbs({
   defaultLayout: 'main',
   helpers: HandlebarHelpers,

--- a/app/jenkins-hook.js
+++ b/app/jenkins-hook.js
@@ -1,8 +1,8 @@
-import app from './index.js';
-import { Project } from './models/project';
-const config = require('../config.json');
+import app from 'houston/app';
+import { Project } from 'houston/app/models/project';
+import CONFIG from 'houston/config.json';
 
-app.post('/jenkins-hook/' + config.JENKINS_SECRET, function(req, res) {
+app.post('/jenkins-hook/' + CONFIG.JENKINS_SECRET, function(req, res) {
   Project.updateBuild(req.body.build)
     .then(function() {
       res.end('ok');

--- a/app/models/jenkins.js
+++ b/app/models/jenkins.js
@@ -1,5 +1,5 @@
-import app from '../index.js';
-var CONFIG = require.main.require('./config');
+import app from 'houston/app';
+import CONFIG from 'houston/config.json';
 import jenkinsClient from 'then-jenkins';
 
 if (CONFIG.JENKINS_ENABLED) {

--- a/app/models/project.js
+++ b/app/models/project.js
@@ -1,10 +1,10 @@
 import mongoose from 'mongoose';
 import Hubkit from 'hubkit';
-import Jenkins from './jenkins';
+import Jenkins from 'houston/app/models/jenkins';
 
-import app from '../index.js';
-import { BuildSchema } from './build.js';
-import { ChangeLogSchema } from './changelog.js';
+import app from 'houston/app';
+import { BuildSchema } from 'houston/app/models/build.js';
+import { ChangeLogSchema } from 'houston/app/models/changelog.js';
 
 // Create an instance of Hubkit
 var gh = new Hubkit({});

--- a/app/mongodb.js
+++ b/app/mongodb.js
@@ -1,9 +1,9 @@
 import mongoose from 'mongoose';
 
-import app from './index.js';
-const config = require('../config.json');
+import app from 'houston/app';
+import CONFIG from 'houston/config.json';
 
-mongoose.connect(config.MONGODB_URL);
+mongoose.connect(CONFIG.MONGODB_URL);
 
 mongoose.connection.on(
   'error',

--- a/app/project.js
+++ b/app/project.js
@@ -1,8 +1,8 @@
 import _ from 'underscore';
 
-import app from './index.js';
-import { Project } from './models/project';
-import { loggedIn } from './auth';
+import app from 'houston/app';
+import { Project } from 'houston/app/models/project';
+import { loggedIn } from 'houston/app/auth';
 
 // Show project information
 app.get('/project/gh/:org/:name', loggedIn, function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "postinstall" : "ln -sfvT ../ ./node_modules/houston",
     "start": "./node_modules/.bin/babel-node ./server"
   },
   "dependencies": {


### PR DESCRIPTION
Hey Avi, maybe we should use a symlink to link node_modules to the houston code, then we can use `require('houston/some_code);` to import easily, or with es6 syntax: `import app from 'houston/app';`
