### PR TITLE
Add .bundle/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.json
 npm-debug.log
 .DS_Store
 .vagrant
+.bundle


### PR DESCRIPTION
This directory is created by Vagrant, which is a bug with vagrant itself. See https://github.com/mitchellh/vagrant/issues/6705 for upstream info.