### PR TITLE
add line breaks and padding to error page

### DIFF
--- a/views/error.handlebars
+++ b/views/error.handlebars
@@ -1,4 +1,6 @@
 {{> nav-secondary}}
 
-<h1>{{message}}</h1>
-<pre>{{error.stack}}</pre>
+<div style="padding: 15px">
+  <h1>{{message}}</h1>
+  <pre style="white-space: pre-wrap">{{error.stack}}</pre>
+</div>


### PR DESCRIPTION
yeah, yeah, they're inline styles. if someone's is deep offended by that, I guess we could split them out into a separate CSS file.