### PR TITLE
word choice changes

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+# The MIT License (MIT)
+
+### Copyright © 2016 elementary & [The Web Team](https://github.com/elementary/houston/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+-----------------------------------------------------------------------------
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,56 +1,86 @@
 # Houston
 **Prepare for liftoff.**
 
-The concept of Houston is to create a developer dashboard and backend for converting GitHub repos into Debian packages. Developers create a repo containing a `.apphub` file which is then shown on their dashboard. Houston reports the status of the repo here:
+Houston is a developer dashboard and backend for converting GitHub repos into
+Debian packages. Developers create a repo containing a `.apphub` file which is
+then shown on their dashboard. From there Houston will clone, test, build, and
+publish your application to AppHub.
 
-* Needs Release: This repo needs a new git tag that is not already associated with a build and with a suitable changelog before it can be published
-* Publish: The repo has a git tag that doesn't already have an associated build
-* In Progress: The repo is currently being tested or built.
-* Failure: The repo was not succesfully published as a debian package due to build failure or test suite failure. At this stage, houston will file issues with more detail into the repo's GitHub issues tracker
-* Needs Review: The git repo was succesfully built into a debian package and requires a human to move it from the "testing" deb repo to the "stable" deb repo. After this task is completed, start over with "Needs Release" status.
+[Learn more](https://docs.google.com/a/elementaryos.org/document/d/1nHCnxNpaQI8G2VdJKFeri12krLpgtUQllMj8_PdZ7P8/edit?usp=sharing)
+about the technical details.
+
 
 ## Architecture Overview
+
 * HTML/CSS/JS
 * [Handlebars](http://handlebarsjs.com/) templates
-* [Node.js](https://nodejs.org/en/) backend ([ES2015 syntax](git.io/es6features) via [Babel](babeljs.io))
-* [GitHub OAuth API](https://developer.github.com/v3/oauth/)
-* [Jenkins](https://jenkins-ci.org/)
-* [MongoDB](https://www.mongodb.org/)
+* [Node.js](https://nodejs.org/en/) backend
+  ([ES2015 syntax](https://git.io/es6features) via [Babel](https://babeljs.io))
+* [GitHub OAuth API](https://developer.github.com/v3/oauth/) via
+  [Passport](https://github.com/jaredhanson/passport-github)
+* [MongoDB](https://www.mongodb.org/) with
+  [Mongoose](https://github.com/Automattic/mongoose)
 * [Stripe Connect](https://stripe.com/connect)
-* [Liftoff](https://github.com/elementary/liftoff) (Cody's build scripts, repo currently private)
-* **[Learn more](https://docs.google.com/document/d/1nHCnxNpaQI8G2VdJKFeri12krLpgtUQllMj8_PdZ7P8/edit)**
+* [Liftoff](https://github.com/elementary/liftoff)
+  (Cody's build scripts, repo currently private)
 
-Houston is the glue between GitHub and our repository system. Ideally when you first create a project on GitHub, you would go to houston and initialize the repository. This will setup houston to monitor the repository with GitHub hooks (eventually, for now it's manual with houston's web interface).
+Houston is the glue between GitHub and our repository system. Ideally when you
+first create a project on GitHub, you would go to Houston and initialize the
+repository. This will setup Houston to monitor the repository with GitHub hooks.
 
-When a release is created on GitHub, and you choose to publish that release through Houston, Houston will run some tests on it. These tests currently include automatically checking for an app icon, and some strings in the .desktop file. It will be expanded in the future. At the same time, the repository will be passed to Jenkins, which will build the repo into a deb package. After it's built, a person from elementary will install the application and test for a multitude of things including but not limited to performance, aesthetics, and nativeness.
+When a release is created on GitHub, you will get an option to publish that
+release in Houston's dashboard. Houston will then clone the repository, run
+tests on the code, build the code with
+[Liftoff](https://github.com/elementary/liftoff), and publish it to a
+**testing** repository. At this point someone from elementary will install the
+application and continue running tests. This ensures the best performance, user
+experience, and desktop integration for any application in AppHub.
 
-If the test fails, Houston will file an issue on GitHub explaining what the problem is, and some advice to fix it. If there are warnings, Houston will still file an issue, but will continue onto the next step.
+If any test fails, Houston will submit an issue on GitHub with detailed
+information on the problems, and in some cases, solutions to fix it. After
+fixing these issues you will be able to resubmit your application for
+publishing.
 
-At this point, the approved deb file will be moved into the stable repo. We will be using [Freight](https://github.com/rcrowley/freight) behind nginx to host the Debian repository. Ultimately this repository will be the focus of [AppCenter](https://launchpad.net/appcenter) and the whole elementary OS 3rd party app ecosystem.
+At this point, the approved application will be moved into the stable repo, and
+available to all users of elementary OS. We will be using
+[aptly](https://github.com/smira/aptly) behind nginx to host the repository.
+Ultimately this repository will be the focus of
+[AppCenter](https://launchpad.net/appcenter) and the elementary OS 3rd party
+app ecosystem.
+
 
 ## Hacking on Houston (how-to)
 
-We'd love your help hacking on Houston! Getting a local development environment set up is easy, and we've prepared a short guide to walk you through step-by-step. Just follow along below, and if you have any issues, don't hesitate to [ask for help](https://github.com/elementary/houston/issues/new).
+We'd love your help hacking on Houston! Getting a local development environment
+set up is easy, and we've prepared a short guide to walk you through
+step-by-step. Just follow along below, and if you have any issues, don't
+hesitate to [ask for help](https://github.com/elementary/houston/issues/new).
 
-To get started working on Houston:
 
-1. You'll need to set up Houston's config file, `config.js`. Copy the config file template:
+#### Configuration
 
-  ```cp config.example.js config.js```
+1. You'll need to set up Houston's config file, `config.js`. Copy the config
+  file template:
 
-2. Then, create a GitHub OAuth application for testing Houston: https://github.com/settings/applications/new.
+  `cp config.example.js config.js`
 
-  Name the application "Houston Local", and set the homepage and callback URLs to your local machine, like this:
+2. Then, create a GitHub OAuth application for testing Houston:
+  https://github.com/settings/applications/new.
 
-   `homepage`: http://localhost:3000
+  Name the application "Houston Local", and set the homepage and callback URLs
+  to your local machine, like this:
 
-   `callback URL`: http://localhost:3000/auth/github/callback
+   Homepage URL: http://localhost:3000
+
+   Authorization callback URL: http://localhost:3000/auth/github/callback
 
    It should look something like this:
 
    ![](https://i.imgur.com/PGKT7GC.png)
 
-3. Click Register application, and then copy and paste the newly created application's Client ID into `config.js` under `github.clientID` and copy the Client Secret under `github.secret`.
+3. Click 'Register application', and then copy and paste the newly created
+  application's Client ID into `config.js` under `github.clientID` and copy the
+  Client Secret under `github.secret`.
 
    ![](https://i.imgur.com/D0VxJcX.png)
 
@@ -69,34 +99,68 @@ To get started working on Houston:
   },
   ```
 
-We use [Vagrant](https://www.vagrantup.com/) to simplify management of our local development environments. Or you can skip the steps below to develop without Vagrant:
 
-1. Setting up Vagrant is super simple. Just download and install [Vagrant](https://www.vagrantup.com/downloads.html) and [VirtualBox](https://www.virtualbox.org/wiki/Downloads). If you're running elementary OS or Ubuntu, you can use:
+#### Vagrant
 
-  ```sudo apt-get install vagrant virtualbox```
+We use [Vagrant](https://www.vagrantup.com/) to simplify management of our local
+development environments. This ensures you have the correct versions of all
+dependencies, and makes it easier to track down bugs. If you would like to
+develop without using Vagrant you can skip this step and continue to the
+[barebones](#barebones) instructions.
 
-2. Run `vagrant up` from the root of the directory where you cloned this repository.
+1. Setting up Vagrant is super simple. Just download and install
+  [Vagrant](https://www.vagrantup.com/downloads.html) and
+  [VirtualBox](https://www.virtualbox.org/wiki/Downloads). If you're running
+  elementary OS or Ubuntu, you can run these commands in terminal:
 
-    This will spin up an Ubuntu virtual machine as per our Vagrant file and [rsync](https://en.wikipedia.org/wiki/Rsync) the contents of the repository directory into the VM. If you'd like to connect to the VM and poke around, you can do so with `vagrant ssh`. The synced directory lives in `~/houston`, and logs in `/var/log/houston.log`.
+  `sudo apt-get install vagrant virtualbox`
 
-You can also choose to develop without Vagrant.
+2. Run `vagrant up` from the root of the directory where you cloned this
+  repository.
 
-1. Install MongoDB, Node.js, and NPM
+    This will spin up an Ubuntu virtual machine as per our Vagrant file and
+    [rsync](https://en.wikipedia.org/wiki/Rsync) the contents of the repository
+    directory into the VM. If you'd like to connect to the VM and poke around,
+    you can do so with `vagrant ssh`. The synced directory lives in `~/houston`,
+    and logs in `/var/log/houston.log`.
 
-  ```sudo apt-get install mongodb nodejs-legacy npm```
+
+#### Barebones
+
+Although we prefer using Vagrant for developing, if you wish to avoid it,
+here's what you will need to do.
+
+1. Install MongoDB
+
+  `sudo apt-get install mongodb`
+
+2. Install node and npm
+
+    Depending on your distribution of choice, you might need to download and
+    compile node from the [website](https://nodejs.org). Keep in mind that
+    Houston requires node version `4.2.6` or above.
 
 2. run `npm install` to fetch needed dependencies.
 3. Start the server with `npm start`
 
 
-In either case, open up a browser and visit http://localhost:3000, and you should see the Houston website. If you do — congratulations, you're all ready to hack on Houston!
+#### Accessing
 
-Please take a look at the [open issues](https://github.com/elementary/houston/issues) and submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request/) with your changes :) We really appreciate your help!
+In either case, open up a browser and visit http://localhost:3000, and you
+should see the Houston website. If you do — congratulations, you're all ready
+to hack on Houston!
+
+Please take this time to read the [contributing]($contributing) guidelines
+before working on [open issues](https://github.com/elementary/houston/issues)
+and submitting
+[pull requests](https://help.github.com/articles/creating-a-pull-request).
+
 
 ## Contributing
 
-Because we use a lot of new JavaScript code styles, it is strongly recommended to
-read up on promises, and [ES6 shorthand](https://github.com/lukehoban/es6features).
+Because we use a lot of new JavaScript code styles, it is strongly recommended
+to read up on promises, and
+[ES6 shorthand](https://github.com/lukehoban/es6features).
 
 Some things to keep note of while programming:
 * If you don't change a variable, declare it with `const` vs `var`.
@@ -106,8 +170,11 @@ Some things to keep note of while programming:
 * Template strings are here to help. Use them.
 * Comments don't hurt.
 * Promises always return some value, error or not.
-* It is standard to return in promise with `return Promise.resolve(null)` vs `return null`.
+* It is standard to return in promise with `return Promise.resolve(null)` vs
+  `return null`.
 
-We [lint](https://en.wikipedia.org/wiki/Lint_(software)) our JavaScript code with [JSCS](http://jscs.info) to ensure our code is consistently styled and formatted.
+We [lint](https://en.wikipedia.org/wiki/Lint_(software) our JavaScript code
+with [JSCS](http://jscs.info) to ensure our code is consistently styled and
+formatted. For simplicity you can run `npm test` to check for code consistency.
 
 Please lint your code before submitting a pull request :)

--- a/app/controller/project.js
+++ b/app/controller/project.js
@@ -5,7 +5,7 @@ import app from '~/';
 import { Application } from '~/model/application';
 import { hasRole } from './auth';
 
-// Delete the project from houston
+// Delete the project from Houston
 app.get('/project/gh/:org/:name/initialize', hasRole('beta'), function(req, res) {
   const gh = new Hubkit({token: req.user.github.accessToken});
 
@@ -46,7 +46,7 @@ app.get('/project/gh/:org/:name/build', hasRole('beta'), (req, res, next) => {
   });
 });
 
-// Delete the project from houston
+// Delete the project from Houston
 app.get('/project/gh/:org/:name/delete', hasRole('beta'), function(req, res) {
   Application.findOne({
     'github.owner': req.params.org,

--- a/app/index.js
+++ b/app/index.js
@@ -25,7 +25,7 @@ app.config = {}
 try {
   fs.statSync(path.join(__dirname, '../config.js'));
 } catch (err) {
-  throw new Error('It seems like you have not setup houston, we have a example config file for you, please set it up.');
+  throw new Error('It seems like you have not setup Houston, we have a example config file for you, please set it up.');
 }
 
 app.config = require(path.join(__dirname, '../config.js'));

--- a/app/model/application.js
+++ b/app/model/application.js
@@ -26,7 +26,7 @@ const ApplicationSchema = new mongoose.Schema({
       default: 'AppHub',
     },
   },
-  initalized: {                  // If the application is ready for houston
+  initalized: {                  // If the application is ready for Houston
     type:       Boolean,
     default:    false,
   },

--- a/package.json
+++ b/package.json
@@ -1,38 +1,52 @@
 {
-  "name": "houston",
-  "version": "0.0.0",
-  "private": true,
-  "scripts": {
-    "start": "node server.js"
-  },
+  "name": "Houston",
+  "version": "0.0.1",
+  "description": "Backend for AppHub",
+  "main": "server.js",
   "dependencies": {
-    "babel-plugin-transform-async-to-generator": "^6.3.13",
-    "babel-plugin-transform-regenerator": "^6.3.26",
-    "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-register": "^6.3.13",
+    "babel-plugin-transform-async-to-generator": "^6.5.0",
+    "babel-plugin-transform-regenerator": "^6.5.0",
+    "babel-polyfill": "^6.5.0",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-register": "^6.5.1",
     "babel-root-import": "^3.1.0",
-    "bluebird": "^2.9.30",
-    "body-parser": "~1.12.3",
-    "connect-mongo": "^0.8.1",
-    "cookie-parser": "~1.3.4",
-    "debug": "~2.1.3",
+    "bluebird": "^3.2.2",
+    "body-parser": "^1.14.2",
+    "connect-mongo": "^1.1.0",
+    "cookie-parser": "^1.4.1",
     "dotize": "^0.1.26",
-    "express": "~4.12.2",
-    "express-handlebars": "~3.0.0",
-    "express-session": "~1.11.1",
+    "express": "^4.13.4",
+    "express-handlebars": "^3.0.0",
+    "express-session": "^1.13.0",
     "express-winston": "^1.2.0",
-    "hubkit": "~0.1.31",
+    "hubkit": "^0.3.3",
     "ini": "^1.3.4",
     "kerberos": "0.0.18",
-    "lodash": "^3.10.1",
-    "mongoose": "~4.3.7",
-    "morgan": "~1.5.2",
-    "passport": "~0.2.1",
-    "passport-github": "~0.1.5",
+    "lodash": "^4.3.0",
+    "mongoose": "^4.4.2",
+    "morgan": "^1.6.1",
+    "passport": "^0.3.2",
+    "passport-github": "^1.1.0",
     "semver": "^5.1.0",
-    "serve-favicon": "~2.2.0",
-    "then-jenkins": "~0.7.1",
+    "serve-favicon": "^2.3.0",
+    "then-jenkins": "^0.7.1",
     "winston": "^2.1.1"
-  }
+  },
+  "devDependencies": {
+    "jscs": "^2.9.0"
+  },
+  "scripts": {
+    "test": "jscs .",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elementary/houston.git"
+  },
+  "author": "elementary",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/elementary/houston/issues"
+  },
+  "homepage": "https://github.com/elementary/houston#readme"
 }

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -46,7 +46,7 @@
       </div>
     {{else}}
       <h3>No elementary apps found!</h3>
-      An <code>.apphub</code> file in the root of the repo is how houston
+      An <code>.apphub</code> file in the root of the repo is how Houston
       knows which apps to look at.
     {{/each}}
 </div>


### PR DESCRIPTION
Spent some time reading over the `README.md` and completing the `package.json`.

* Quite a bit of packages are updated
* All public facing instances of 'houston' are now 'Houston'
* Added a `LICENSE.md` (copy from mvp)
* Changed some words around in the `README.md`. Most notably the description, and the hacking area. It is now more clear that a recent version of node is needed.