### PR TITLE
Fixed Mongodb identifier in Jenkins hook

### DIFF
--- a/core/model/build.js
+++ b/core/model/build.js
@@ -76,7 +76,7 @@ BuildSchema.methods.doBuild = async function () {
         ARCH: this.arch,
         CHANGELOG: changelog,
         REFERENCE: await cycle.getTag(),
-        IDENTIFIER: this._id
+        IDENTIFIER: this._id.toString()
       }
     })
     .then(build => this.update({ build }))


### PR DESCRIPTION
Needs to be a String, was some kind of internal mongoose Object ...