### PR TITLE
use rabbitbot to create issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 /**
  * app.js
- * Consolidates all of Houston to a single file
+ * Consolidates all of Houston's needs into a single file
  *
  * @exports {Object} Helpers
  * @exports {Object} Config
@@ -32,6 +32,29 @@ try {
 }
 
 app.config = require('./config.js')
+
+let exampleExists = true
+try {
+  require('./config.example.js')
+} catch (err) {
+  exampleExists = false
+}
+
+if (exampleExists) {
+  const example = require('./config.example.js')
+
+  for (let k in app.config) {
+    if (!app.config[k]) continue
+    if (!example[k]) continue
+    if (Object.keys(app.config[k]).length < Object.keys(example[k]).length) {
+      console.log(`You are missing ${k} configuration settings`)
+      console.log("Please check 'config.example.js' for new settings")
+      throw new Error('Missing configuration')
+    }
+  }
+}
+
+app.config.server.port = app.config.server.url.split(':')[2]
 
 if (process.env.NODE_ENV != null) app.config.env = process.env.NODE_ENV
 if (process.env.PORT != null) app.config.server.port = process.env.PORT
@@ -93,12 +116,16 @@ export const Log = app.log
 app.db = Mongoose.connect(app.config.database)
 app.db.Promise = Promise
 
-app.db.connection.on('error', function (msg) {
-  throw new Error(msg)
+app.db.connection.on('error', (msg) => {
+  app.log.error(msg)
 })
 
-app.db.connection.once('open', function () {
+app.db.connection.once('open', () => {
   app.log.info('Connected to database')
+})
+
+app.db.connection.once('close', () => {
+  app.log.info('Disconnected to database')
 })
 
 export const Db = app.db

--- a/appHooks/apphub/issue.md
+++ b/appHooks/apphub/issue.md
@@ -2,11 +2,11 @@
 
 {% block title %}
 {% if errors.length == 1 %}
-`.apphub` has an issue
+.apphub has an issue
 {% elif errors.length > 1 %}
-`.apphub` has issues
+.apphub has issues
 {% else %}
-`.apphub` has some concerns
+.apphub has some concerns
 {% endif %}
 {% endblock %}
 

--- a/appHooks/desktop/issue.md
+++ b/appHooks/desktop/issue.md
@@ -1,7 +1,7 @@
 {% extends issue %}
 
 {% block title %}
-`{{ data.project.name }}.desktop` has a problem
+{{ data.project.name }}.desktop has a problem
 {% endblock %}
 
 {% block issue %}

--- a/config.example.js
+++ b/config.example.js
@@ -10,8 +10,11 @@
 
 // https://github.com/settings/developers
 export const github = {
-  client: '12345679101112131415',
-  secret: '1234567891011121314151617181920212223242',
+  client: '78zx9c4vb8xc4v5647ar',
+  secret: '4ra56dsv489asd4r56b456a489sd7ft89a75s4b8',
+
+  // User access token for submitting issues
+  access: 'ar4sd56v456as4edr564s5dv6a45sr156we48zxw',
 
   // Post data to GitHub?
   post: false,
@@ -61,7 +64,6 @@ export const aptly = {
 export const database = 'mongodb://localhost/houston-dev'
 
 export const server = {
-  port: 3000,
   secret: 'hiGvpfbJhSNlC15OXiCxXWcEUYVeKBqb',
 
   // Full route including port and protocol, without trailing slash

--- a/core/io.js
+++ b/core/io.js
@@ -17,10 +17,10 @@ const InitIo = Server => {
 // TODO: handshake and security stuff
 io.on('connection', socket => {
   socket.emit('connection')
-  Log.info(`Now controlling ${Helpers.ArrayString('slave', io.engine.clientsCount)}.`)
+  Log.info(`Now controlling ${Helpers.ArrayString('slave', io.engine.clientsCount)}`)
 
   socket.on('disconnect', socket => {
-    Log.info(`Now controlling ${Helpers.ArrayString('slave', io.engine.clientsCount)}.`)
+    Log.info(`Now controlling ${Helpers.ArrayString('slave', io.engine.clientsCount)}`)
   })
 
   socket.on('report', (message, data) => {

--- a/core/service/github.js
+++ b/core/service/github.js
@@ -12,6 +12,15 @@ import Semver from 'semver'
 
 import { Config, Request, Log } from '~/app'
 
+/**
+ * GetReleases
+ * Returns mapped array of releases from GitHub project
+ *
+ * @param {String} owner - GitHub owner
+ * @param {String} name - GitHub project
+ * @param {String} token - GitHub authentication token
+ * @returns {Array} - Mapped releases
+ */
 export function GetReleases (owner, name, token) {
   return Request
   .get(`https://api.github.com/repos/${owner}/${name}/releases`)
@@ -31,6 +40,13 @@ export function GetReleases (owner, name, token) {
   })
 }
 
+/**
+ * GetProjects
+ * Returns mapped array of projects
+ *
+ * @param {String} token - GitHub authentication token
+ * @returns {Array} - Mapped projects
+ */
 export function GetProjects (token) {
   return Request
   .get(`https://api.github.com/user/repos?visibility=public`)
@@ -57,6 +73,13 @@ export function GetProjects (token) {
   })
 }
 
+/**
+ * SendLabel
+ * Creates label for GitHub project issues
+ *
+ * @param {Object} project - Database object for a project
+ * @returns {Promise} - Empty promise of success
+ */
 export function SendLabel (project) {
   if (!Config.github.post) {
     Log.verbose('GitHub config prohibits posting. Not posting label')
@@ -83,6 +106,17 @@ export function SendLabel (project) {
   })
 }
 
+/**
+ * SendIssue
+ * Creates issue for GitHub project
+ *
+ * @param {Object} issue - {
+ *   {String} title - Issue title
+ *   {String} body - Issue body
+ * }
+ * @param {Object} project - Database object of project
+ * @returns {Promise} - Empty promise of success
+ */
 export function SendIssue (issue, project) {
   if (!Config.github.post) {
     Log.verbose('GitHub config prohibits posting. Not submitting issue')
@@ -92,13 +126,22 @@ export function SendIssue (issue, project) {
 
   return Request
   .post(`https://api.github.com/repos/${project.github.fullName}/issues`)
-  .auth(project.github.token)
+  .auth(Config.github.access)
   .send(JSON.stringify({
     title: issue.title,
-    body: issue.body,
-    labels: [project.github.label]
+    body: issue.body
   }))
-  .then(data => {
-    Log.debug(`Sent issue to ${project.github.fullName} on GitHub`)
+  .then(res => res.body)
+  .then(res => {
+    return Request
+    .patch(`https://api.github.com/repos/${project.github.fullName}/issues/${res.number}`)
+    .auth(project.github.token)
+    .send(JSON.stringify({
+      labels: [ project.github.label ]
+    }))
+    .then(data => {
+      Log.debug(`Sent issue to ${project.github.fullName} on GitHub`)
+      return Promise.resolve()
+    })
   })
 }


### PR DESCRIPTION
Fixes #115 

Includes some other fixes, but overall it will use the the config's `github.access` token to create new issues, then use the project's developer (need push access) to add the label to the issue.

Random fixes include:
* Don't use markdown in issue titles
* Why is there a period in a log function?
* Add some documentation to GitHub service
* Check for missing config settings if there is an example file