### PR TITLE
Disable ARM Builds by default

### DIFF
--- a/core/model/project.js
+++ b/core/model/project.js
@@ -74,7 +74,7 @@ const ProjectSchema = new Mongoose.Schema({
   },
   architectures: {                // Architect for Builds
     type: [String],
-    default: ['amd64', 'armhf']
+    default: ['amd64']
   },
 
   cycles: [{


### PR DESCRIPTION
Because they are currently broken