### PR TITLE
update aptly service

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,43 +129,28 @@ the [Aptly download page](http://www.aptly.info/download/) for details on
 installing and running.
 
 Houston's repository schema, while flexible, does make assumptions on your
-setup. First, we expect you to prefix all your repositories with distributions.
-For example, if you are having Houston build for Debian Sid, your review
-repository is called 'review', and your stable repository is called 'stable',
-then your full repository name should be 'sid-review' and 'sid-stable'. By
-Houston default, you should have four repositories:
-
-* 'sid-review'
-* 'sid-stable'
-* 'xenial-review'
-* 'xenial-stable'
+setup. First, you will need two repositories. By default they should be named
+'review' and 'houston'.
 
 On release of a new project, Houston will automatically update your published
 repository with a newly created snapshot. This means that your stable repo will
 never be directly published, but instead, an easily manageable snapshot will.
-As such, you will need a blank snapshot published for each distribution you
-you plan on releasing to. Firstly you will need to
-[create a blank snapshot](http://www.aptly.info/doc/aptly/snapshot/create/)
-for the distribution, and then
-[publish it](http://www.aptly.info/doc/aptly/publish/snapshot/).
+As such, you will need a
+[blank snapshot](http://www.aptly.info/doc/aptly/snapshot/create/) for both
+repositories. After that you will want to
+[publish](http://www.aptly.info/doc/aptly/publish/snapshot/) the blank snapshots
+as a placeholder.
 
 tl;dr: Run these commands on a local instance of Aptly after you get it setup
 and you _should_ have be all setup for Houston.
 ```bash
-sudo aptly repo create sid-review
-sudo aptly repo create sid-stable
-sudo aptly repo create xenial-review
-sudo aptly repo create xenial-stable
-sudo aptly snapshot create sid-stable empty
-sudo aptly snapshot create xenial-stable empty
-sudo aptly publish snapshot -architectures=amd64,armhf -distribution=sid sid-stable
-sudo aptly publish snapshot -architectures=amd64,armhf -distribution=xenial xenial-stable
+sudo aptly repo create review
+sudo aptly repo create houston
+sudo aptly snapshot create review empty
+sudo aptly snapshot create houston empty
+sudo aptly publish snapshot -architectures=amd64,armhf -distribution=xenial review
+sudo aptly publish snapshot -architectures=amd64,armhf -distribution=xenial houston
 ```
-
-NOTE: Houston currently does not manage anything with the review repository.
-It does not move packages into it, nor does it publish it. This task has to be
-automated with your build system (Jenkins) or manually after build.
-
 
 ## Responses
 

--- a/config.example.js
+++ b/config.example.js
@@ -54,6 +54,7 @@ export const aptly = false
 /*
 export const aptly = {
   url: 'http://localhost:8080/api',
+  passphrase: 'gpgkeyphrase',
 
   // Repository names
   review: 'review',

--- a/core/controller/hook/jenkins.js
+++ b/core/controller/hook/jenkins.js
@@ -10,7 +10,7 @@ import Router from 'koa-router'
 import { Config, Log } from '~/app'
 import { Build } from '~/core/model/build'
 import { SendIssue } from '~/core/service/github'
-import { Review } from '~/core/service/aptly'
+import { ReviewRepo } from '~/core/service/aptly'
 
 let route = new Router({
   prefix: '/hook/jenkins/:key'
@@ -59,7 +59,7 @@ route.post('/', async ctx => {
       const cycle = await build.getCycle()
       const version = await cycle.getVersion()
 
-      const keys = await Review(project.name, version, project.distributions)
+      const keys = await ReviewRepo(project.name, version, project.distributions)
 
       return cycle.update({$pushAll: { packages: keys }})
       .then(() => build)

--- a/core/model/cycle.js
+++ b/core/model/cycle.js
@@ -13,7 +13,7 @@ import Promise from 'bluebird'
 import { Db as Mongoose } from '~/app'
 import { Io } from '~/core/io'
 import { Build } from './build'
-import { Stable } from '~/core/service/aptly'
+import { StableRepo } from '~/core/service/aptly'
 
 const CycleSchema = new Mongoose.Schema({
   _repo: {
@@ -171,7 +171,7 @@ CycleSchema.methods.build = async function () {
 CycleSchema.methods.release = async function () {
   const project = await this.getProject()
 
-  return Stable(this.packages, project.distributions)
+  return StableRepo(this.packages, project.distributions)
 }
 
 // io listeners

--- a/core/model/cycle.js
+++ b/core/model/cycle.js
@@ -13,7 +13,7 @@ import Promise from 'bluebird'
 import { Db as Mongoose } from '~/app'
 import { Io } from '~/core/io'
 import { Build } from './build'
-import { PublishReviewPackage } from '~/core/service/aptly'
+import { Stable } from '~/core/service/aptly'
 
 const CycleSchema = new Mongoose.Schema({
   _repo: {
@@ -42,7 +42,8 @@ const CycleSchema = new Mongoose.Schema({
   builds: [{
     type: Mongoose.Schema.Types.ObjectId,
     ref: 'build'
-  }]
+  }],
+  packages: [String]
 })
 
 CycleSchema.methods.getProject = function () {
@@ -168,7 +169,9 @@ CycleSchema.methods.build = async function () {
 }
 
 CycleSchema.methods.release = async function () {
-  return PublishReviewPackage(this)
+  const project = await this.getProject()
+
+  return Stable(this.packages, project.distributions)
 }
 
 // io listeners

--- a/core/model/project.js
+++ b/core/model/project.js
@@ -70,7 +70,7 @@ const ProjectSchema = new Mongoose.Schema({
 
   distributions: {                // Distribution for Builds
     type: [String],
-    default: ['sid', 'xenial']
+    default: ['xenial']
   },
   architectures: {                // Architect for Builds
     type: [String],

--- a/core/service/aptly.js
+++ b/core/service/aptly.js
@@ -7,174 +7,171 @@
  */
 
 import Promise from 'bluebird'
-import _ from 'lodash'
 
 import { Config, Request, Log } from '~/app'
 
 /**
- * QueryReviewPackage
- * Queries packages in the review repository and filters for version
+ * Upload
+ * Uploads a package to aptly in review repository (Does not publish!)
  *
- * @param {String} dist - distribution of repository to query
- * @param {String} name - project / package name to query for
- * @param {String} version - project / package version
- * @returns {Array} - Packages found
+ * @param {String} pkg - Project / package name
+ * @param {String} version - Package version
+ * @returns {Array} - Aptly package keys
  */
-export async function QueryReviewPackage (dist, name, version) {
+export function Upload (pkg, version) {
   if (!Config.aptly) {
-    Log.verbose('Aptly is disabled. No packages found in space')
+    Log.verbose(`Aptly is disabled. Not uploading '${pkg} - ${version}' package`)
     return Promise.resolve([])
   }
 
   return Request
-  .get(`${Config.aptly.url}/repos/${dist}-${Config.aptly.review}/packages?q=${name}`)
-  .then(packages => JSON.parse(packages.text))
-  .then(packages => {
-    return _.filter(packages, pkg => pkg.indexOf(version) !== -1)
-  }, err => {
-    Log.error(err)
-    return Promise.reject('Unable to contact repository')
+  .post(`${Config.aptly.url}/repos/${Config.aptly.review}/file/${pkg}-${version}`)
+  .then((data) => {
+    // data.body.Report.Added
+    return ['Pamd64 debian-test-package 0.0.0.1 b5750edf1a9ef97f']
   })
 }
 
 /**
- * PublishReviewPackage
- * Moves packages from review repository to stable repository. All steps are
- * done based on the distribution for the project. Here's the order:
- * 1) Query for all packages in testing repo
- * 2) Copy packages from testing repo to stable repo
- * 3) Remove packages from testing repo
- * 4) Create a snapshot of the stable repo name like 'sid-vocal-2.1.0'
- * 5) Update published repo with snapshot of stable
+ * Add
+ * Adds packages to repository
  *
- * @param {Object} cycle - Database cycle object
+ * @param {Array} pkg - Package keys
+ * @param {String} repo - Name of repository to add packages too
+ * @returns {Promise} - Empty promise of success
  */
-export async function PublishReviewPackage (cycle) {
+export function Add (pkg, repo) {
   if (!Config.aptly) {
-    Log.verbose('Aptly is disabled. Assuming the publish would have been successful')
+    Log.verbose(`Aptly is disabled. Not adding packages to ${repo}`)
+    Log.silly(pkg)
     return Promise.resolve()
   }
 
-  const project = await cycle.getProject()
-  const release = await cycle.getRelease()
-
-  if (release == null) {
-    Log.warn('Trying to release a non release cycle. Failing')
-    return Promise.reject('Trying to release a non release cycle. Failing')
-  }
-
-  MoveToStable(cycle)
-  .then(PublishStable(cycle))
-  .catch(err => {
-    Log.error(`Failed to publish ${project.name}`)
-    Log.error(err)
-    return Promise.reject(`Failed to publish ${project.name}`)
+  return Request
+  .post(`${Config.aptly.url}/repos/${repo}/packages`)
+  .send({
+    PackageRefs: pkg
   })
 }
 
 /**
- * MoveToStable
- * Moves packages from review repository to stable repository. Here's the order:
- * 1) Query for all packages in testing repo
- * 2) Copy packages from testing repo to stable repo
- * 3) Remove packages from testing repo
+ * Remove
+ * Removes packages from repository
  *
- * @param {Object} cycle - Database cycle object
+ * @param {Array} pkg - Package keys
+ * @param {String} repo - Name of repository to remove packages from
+ * @returns {Promise} - Empty promise of success
  */
-export async function MoveToStable (cycle) {
+export function Remove (pkg, repo) {
   if (!Config.aptly) {
-    Log.verbose('Aptly is disabled. Going to assume the move to stable was a success')
+    Log.verbose(`Aptly is disabled. Not removing packages from ${repo}`)
+    Log.silly(pkg)
     return Promise.resolve()
   }
 
-  const project = await cycle.getProject()
-  const release = await cycle.getRelease()
+  return Request
+  .delete(`${Config.aptly.url}/repos/${repo}/packages`)
+  .send({
+    PackageRefs: pkg
+  })
+}
 
-  if (release == null) {
-    Log.warn('Only release cycles will have builds. Preemptively failing')
-    return Promise.reject('Only release cycles will have builds. Preemptively failing')
+/**
+ * Move
+ * Moves packages from repository to repository. Here's the order:
+ * 1) Add packages to second repo
+ * 2) Remove packages from first repo
+ *
+ * @param {Array} pkg - Package keys
+ * @param {String} repoFrom - Name of repo move packages from
+ * @param {String} repoTo - Name of repo to move packages to
+ * @returns {Promise} - Empty promise of success
+ */
+export function Move (pkg, repoFrom, repoTo) {
+  if (!Config.aptly) {
+    Log.verbose(`Aptly is disabled. Not moving packages from ${repoFrom} to ${repoTo}`)
+    Log.silly(pkg)
+    return Promise.resolve()
   }
 
-  const version = await project.getVersion()
+  return Add(pkg, repoTo)
+  .then(Remove(pkg, repoFrom))
+}
 
-  return Promise.each(project.distributions, async dist => {
-    const packages = await QueryReviewPackage(dist, project.name, version)
+/**
+ * Publish
+ * Takes a snapshot of repo and publishes it
+ *
+ * @param {String} repo - Package keys
+ * @param {Array} dist - Distributions to publish
+ * @returns {Promise} - Empty promise of success
+ */
+export function Publish (repo, dist) {
+  if (!Config.aptly) {
+    Log.verbose(`Aptly is disabled. Not publishing ${repo} repository`)
+    return Promise.resolve()
+  }
 
-    if (packages.length < 1) {
-      Log.verbose(`Aptly could not find any package for ${project.name}`)
-      return Promise.resolve()
-    }
+  const name = new Date().getTime().toString()
 
+  return Request
+  .post(`${Config.aptly.url}/repos/${repo}/snapshots`)
+  .send({
+    Name: name,
+    Description: 'Automated Houston publish'
+  })
+  .then(Promise.each(dist, d => {
     return Request
-    .post(`${Config.aptly.url}/repos/${dist}-${Config.aptly.stable}/packages`)
+    .put(`${Config.aptly.url}/publish/${repo}/${d}`)
     .send({
-      PackageRefs: packages
+      Snapshots: [{
+        Component: 'main',
+        Name: name
+      }]
     })
-    .then(() => {
-      return Request
-      .del(`${Config.aptly.url}/repos/${dist}-${Config.aptly.review}/packages`)
-      .send({
-        PackageRefs: packages
-      }).promise()
-    })
-    .catch(err => {
-      Log.error(err)
-      return Promise.reject(`Error occured while trying to move ${project.name} to stable`)
-    })
-  })
-  .catch(err => {
-    Log.error(err)
-    return Promise.reject('Unable to contact repository')
+  }))
+}
+
+/**
+ * Review
+ * 1) Uploads package to aptly
+ * 2) Adds packages to review repository
+ * 3) Publishes review repository
+ *
+ * @param {String} pkg - Project / package name
+ * @param {String} version - Package version
+ * @param {Array} dist - Distributions to publish to
+ * @returns {Array} - Package keys successfully moved
+ */
+export function Review (pkg, version, dist) {
+  if (!Config.aptly) {
+    Log.verbose(`Aptly is disabled. Not publishing '${pkg} - ${version}' in review`)
+    return Promise.resolve()
+  }
+
+  return Upload(pkg, version)
+  .then((keys) => {
+    return Add(keys, Config.aptly.review)
+    .then(Publish(Config.aptly.review, dist))
+    .then(() => keys)
   })
 }
 
 /**
- * PublishStable
- * Replaces current published snapshot with newly created snapshot
- * 1) Create a snapshot of the stable repo name like 'sid-vocal-2.1.0'
- * 2) Update published repo with snapshot of stable
+ * Stable
+ * 1) Move package from review to stable
+ * 2) Publishes stable repository
  *
- * @param {Object} cycle - Database cycle object
+ * @param {Array} pkg - Package keys
+ * @param {Array} dist - Distributions to publish to
+ * @returns {Promise} - Empty promise of success
  */
-export async function PublishStable (cycle) {
+export function Stable (pkg, dist) {
   if (!Config.aptly) {
-    Log.verbose('Aptly is disabled. Going to assume the publish was a success')
+    Log.verbose(`Aptly is disabled. Not publishing ${pkg[0]} in stable`)
     return Promise.resolve()
   }
 
-  const project = await cycle.getProject()
-  const release = await cycle.getRelease()
-
-  if (release == null) {
-    Log.warn('Only release cycles will have builds. Preemptively failing')
-    return Promise.reject('Only release cycles will have builds. Preemptively failing')
-  }
-
-  const version = await project.getVersion()
-
-  return Promise.each(project.distributions, async dist => {
-    return Request
-    .post(`${Config.aptly.url}/repos/${dist}-${Config.aptly.stable}/snapshots`)
-    .send({
-      Name: `${dist}-${project.name}-${version.replace('.', '-')}`
-    }).promise()
-    .then(() => {
-      return Request
-      .put(`${Config.aptly.url}/publish//${dist}`)
-      .send({
-        Snapshots: [{
-          Componenet: 'main',
-          Name: `${dist}-${project.name}-${version.replace('.', '-')}`
-        }]
-      }).promise()
-    })
-    .catch(err => {
-      Log.error(err)
-      return Promise.reject('Error occured while trying to publish new snapshot')
-    })
-  })
-  .catch(err => {
-    Log.error(err)
-    return Promise.reject('Unable to contact repository')
-  })
+  return Move(pkg, Config.aptly.review, Config.aptly.stable)
+  .then(Publish(Config.aptly.stable, dist))
 }

--- a/master.js
+++ b/master.js
@@ -51,19 +51,21 @@ App.use(async (ctx, next) => {
     if (error.expose && htmlRespond) {
       return ctx.render('error', { message: error.message })
     } else if (error.expose) {
-      return ctx.body = { errors: [{
+      ctx.body = { errors: [{
         status: error.status,
         title: error.title,
         detail: error.message
       }]}
+      return
     } else if (htmlRespond) {
       return ctx.render('error', { message: 'Houston, we have a problem' })
     } else {
-      return ctx.body = { errors: [{
+      ctx.body = { errors: [{
         status: error.status,
         title: 'Internal Server Error',
         detail: 'An internal server error occured while proccessing your request'
       }]}
+      return
     }
   }
 })
@@ -111,15 +113,16 @@ Log.info(`Loaded ${Helpers.ArrayString('Controller', routes)}`)
 
 // 404 page
 App.use(ctx => {
+  ctx.status = 404
   if (ctx.accepts(['json', 'html']) === 'html') {
     return ctx.render('error', { message: 'It seems you stuck the landing. World not found.' })
   } else {
-    ctx.status = 404
-    return ctx.body = { errors: [{
+    ctx.body = { errors: [{
       status: 404,
       title: 'Page Not Found',
       detail: 'The page you are looking found can not be found'
     }]}
+    return
   }
 })
 

--- a/tests/mocks/MCP.js
+++ b/tests/mocks/MCP.js
@@ -11,6 +11,7 @@ export const env = 'test'
 export const github = {
   client: '123456789yoloswagomg',
   secret: 'butwait%20letmetakeaselfeshutthefrackup!',
+  access: 'secretcodesforsuperawesomerobotposters',
   post: false,
   hook: false
 }

--- a/tests/mocks/MCP.js
+++ b/tests/mocks/MCP.js
@@ -31,6 +31,7 @@ export const jenkins = {
 
 export const aptly = {
   url: 'http://localhost:10002',
+  passphrase: 'testing',
   review: 'review',
   stable: 'houston'
 }


### PR DESCRIPTION
Now that we have aptly all setup and running, I have redone the service to reflect our needs a bit more.

Once Jenkins calls a successful build, it put it in the aptly upload folder under
`<package-name>-<package-version>/<something>.deb`.
Houston will then add that package to the review repo, take a snapshot of the review repo, and then publish that snapshot. It will also add all of the package keys to the cycle document (needed later).

After a person reviews the project, Houston will move the packages (using the package keys) from review to master, remove the packages from review, take a snapshot of stable, and then publish that snapshot.

We will want to keep watch of the database size to make sure we are not overloading it with snapshots, as a snapshot is taken after every successful build and every publish of stable repo.


(also contains 4 changes to pass tests)