### PR TITLE
assert that we are actually setting response status to a number

### DIFF
--- a/src/houston/index.js
+++ b/src/houston/index.js
@@ -73,21 +73,24 @@ app.use(async (ctx, next) => {
     ctx.app.emit('error', error, ctx)
 
     const pkg = {
-      status: error.status || 500
+      status: 500,
+      detail: null,
+      title: 'Houston has encountered an error'
+    }
+
+    if (error.mistake && typeof error.status === 'number') {
+      pkg.status = error.status
+    }
+
+    if (error.expose || app.env === 'development') {
+      pkg.title = error.message || 'Houston has encountered an error'
     }
 
     if (app.env === 'development') {
       pkg.detail = error.stack
     }
 
-    if (error.expose) {
-      pkg.title = error.message || 'Houston has encountered an error'
-    } else {
-      pkg.title = 'Houston has encountered an error'
-    }
-
     ctx.status = pkg.status
-
     return ctx.render('error', { error: pkg })
   }
 })


### PR DESCRIPTION
fixes part of #182 

Houston was giving an ugly text only response when it was erroring because we were passing the error status, assuming it was a number, but it was instead some text string like 'MONGOERR'. This checks that the status code is a number before passing it on to koa.