### PR TITLE
add file class with basic parsers

### DIFF
--- a/src/flightcheck/file.js
+++ b/src/flightcheck/file.js
@@ -61,11 +61,12 @@ export default class File {
   async read (type = this.type) {
     const existance = await this.exists()
 
-    if (!existance) {
-      return null
-    }
+    if (!existance) return null
 
     const raw = await fs.readFileAsync(this.path, this.options)
+
+    // If it's a file with only whitespace charactors (no real data)
+    if (!/\S/.test(raw)) return {}
 
     if (type) {
       return parses[type].read(raw)

--- a/src/flightcheck/file.js
+++ b/src/flightcheck/file.js
@@ -1,0 +1,97 @@
+/**
+ * flightcheck/file.js
+ * A high level class for file interaction
+ *
+ * @exports {Class} File - high level interaction of files
+ */
+
+import assert from 'assert'
+import path from 'path'
+import Promise from 'bluebird'
+
+import * as fsHelpers from '~/lib/helpers/fs'
+import * as parses from './parsers'
+
+const fs = Promise.promisifyAll(require('fs'))
+
+/**
+ * File
+ * High level interaction of files
+ */
+export default class File {
+
+  /**
+   * Creates a file class
+   *
+   * @param {String} p - Path to the file
+   * @param {String} [type] - Type of parser to use for file
+   * @param {Object} [encoding] - File encoding to use for the file
+   */
+  constructor (p, type, encoding = 'utf-8') {
+    assert(p, 'File requires a path')
+
+    this.path = path.resolve(p)
+    this.type = type
+    this.options = { encoding }
+
+    if (type != null) {
+      assert(parses[type], `File type "${type}" does not exist`)
+    }
+  }
+
+  /**
+   * exists
+   * Checks if the file currently exists
+   *
+   * @returns {Boolean} - true if file exists
+   */
+  exists () {
+    return fs.statAsync(this.path)
+    .then((stat) => stat.isFile())
+    .catch({ code: 'ENOENT' }, () => false)
+  }
+
+  /**
+   * read
+   * Reads file from path and parses it if type is set
+   *
+   * @param {String} [type] - file type to parse as
+   * @returns {Object} - javascript object reporesentation of file
+   */
+  async read (type = this.type) {
+    const existance = await this.exists()
+
+    if (!existance) {
+      return null
+    }
+
+    const raw = await fs.readFileAsync(this.path, this.options)
+
+    if (type) {
+      return parses[type].read(raw)
+    } else {
+      return raw
+    }
+  }
+
+  /**
+   * write
+   * Writes javascript object to file
+   *
+   * @param {Object} data - data to write to file
+   * @param {String} type - file type to write as
+   * @returns {Void}
+   */
+  async write (data, type = this.type) {
+    assert(data, 'File requires something to write')
+
+    let output = data
+
+    if (type) {
+      output = await parses[type].write(data)
+    }
+
+    await fsHelpers.mkdirp(path.dirname(this.path))
+    await fs.writeFileAsync(this.path, output)
+  }
+}

--- a/src/flightcheck/parsers/colon.js
+++ b/src/flightcheck/parsers/colon.js
@@ -16,11 +16,6 @@ import _ from 'lodash'
  * @returns {Object} - a javascript representation of the string
  */
 export async function read (str) {
-  // Test if it's an empty file (no real charactors)
-  if (!/\S/.test(str)) {
-    return {}
-  }
-
   const lines = str.split('\n')
 
   const data = {}

--- a/src/flightcheck/parsers/colon.js
+++ b/src/flightcheck/parsers/colon.js
@@ -1,0 +1,102 @@
+/**
+ * flightcheck/parsers/colon.js
+ * Parses colon seperated lists like the Debian control file
+ *
+ * @exports {Function} read - reads a colon string
+ * @exports {Function} write - writes a colon string
+ */
+
+import _ from 'lodash'
+
+/**
+ * read
+ * Reads a colon seperated string and parses it to javascript object
+ *
+ * @param {String} str - a colon seperated string to parse
+ * @returns {Object} - a javascript representation of the string
+ */
+export async function read (str) {
+  // Test if it's an empty file (no real charactors)
+  if (!/\S/.test(str)) {
+    return {}
+  }
+
+  const lines = str.split('\n')
+
+  const data = {}
+  let current = null
+  let type = 'simple' // @see https://www.debian.org/doc/debian-policy/ch-controlfields.html 5.1 Syntax of control files
+
+  lines.forEach((line) => {
+    const [first, ...extra] = _.trim(line).split(':')
+    const key = _.trim(first)
+
+    if (!/\S/.test(key)) return // empty line
+
+    if (extra.length > 0) { // only what appears to be simple types here
+      current = key
+
+      const value = _.trim(extra.join(':'))
+      const last = value.slice(-1)
+
+      if (last !== ',') {
+        type = 'simple'
+        data[key] = value
+        return
+      }
+
+      // a folded type list (multiple values each on a unique line)
+      type = 'folded'
+      data[key] = [value.slice(0, -1)]
+      return
+    }
+
+    // only folded and multiline types get here
+    if (type === 'folded') {
+      let value = key
+      if (key.slice(-1) === ',') {
+        value = key.slice(0, -1)
+      }
+
+      data[current].push(value)
+      return
+    }
+
+    if (type === 'simple' || type === 'multiline') { // we can't tell a multiline vs simple from the first line
+      type = 'multiline'
+
+      data[current] += `\n${line}` // keep any whitespace around it
+      return
+    }
+  })
+
+  return data
+}
+
+/**
+ * write
+ * Writes a colon seperated string from javascript object
+ *
+ * @param {Object} data - a javascript object to put into string
+ * @returns {String} - a simple string of colon seperated values
+ */
+export async function write (data) {
+  let str = ''
+
+  Object.keys(data).forEach((key) => {
+    const value = data[key]
+
+    if (typeof value === 'string') {
+      str += `${key}: ${value}\n`
+      return
+    }
+
+    const padding = key.length + 2
+    str += `${key}: ${value[0]},\n`
+    for (let i = 1; i < value.length; i++) {
+      str += `${' '.repeat(padding)}${value[i]}${(i + 1 !== value.length) ? ',' : '\n'}\n`
+    }
+  })
+
+  return str
+}

--- a/src/flightcheck/parsers/index.js
+++ b/src/flightcheck/parsers/index.js
@@ -1,0 +1,12 @@
+/**
+ * flightcheck/parsers/index.js
+ * Index for all avalible parses
+ *
+ * @exports {Object} colon - Parses colon seperated lists like the Debian control file
+ * @exports {Object} ini - Uses ini package for parsing files
+ * @exports {Object} json - Reading and writing for json files
+ */
+
+export * as colon from './colon'
+export * as ini from './ini'
+export * as json from './json'

--- a/src/flightcheck/parsers/ini.js
+++ b/src/flightcheck/parsers/ini.js
@@ -1,0 +1,38 @@
+/**
+ * flightcheck/parsers/ini.js
+ * Uses ini package for parsing files
+ *
+ * @exports {Function} read - reads a ini string
+ * @exports {Function} write - writes a ini string
+ */
+
+import ini from 'ini'
+
+/**
+ * read
+ * Reads a ini string and parses it to javascript object
+ *
+ * @param {String} str - a ini string to parse
+ * @returns {Object} - javascript object of ini string
+ */
+export async function read (str) {
+  // Test if it's an empty file (no real charactors)
+  if (!/\S/.test(str)) {
+    return {}
+  }
+
+  return ini.parse(str)
+}
+
+/**
+ * write
+ * Writes a ini string from javascript object
+ *
+ * @param {Object} data - a javascript object to put into string
+ * @returns {String} - a ini string representation of the javascript object
+ */
+export async function write (data) {
+  return ini.stringify(data, {
+    whitespace: true
+  })
+}

--- a/src/flightcheck/parsers/ini.js
+++ b/src/flightcheck/parsers/ini.js
@@ -16,11 +16,6 @@ import ini from 'ini'
  * @returns {Object} - javascript object of ini string
  */
 export async function read (str) {
-  // Test if it's an empty file (no real charactors)
-  if (!/\S/.test(str)) {
-    return {}
-  }
-
   return ini.parse(str)
 }
 

--- a/src/flightcheck/parsers/json.js
+++ b/src/flightcheck/parsers/json.js
@@ -1,0 +1,34 @@
+/**
+ * flightcheck/parsers/json.js
+ * Probably the smallest file you will see in this project
+ *
+ * @exports {Function} read - reads a JSON string
+ * @exports {Function} write - writes a JSON string
+ */
+
+/**
+ * read
+ * Reads a JSON file and parses it to javascript object
+ *
+ * @param {String} str - a JSON string to parse
+ * @returns {Object} - a javascript object of the JSON string
+ */
+export async function read (str) {
+  // Test if it's an empty file (no real charactors)
+  if (!/\S/.test(str)) {
+    return {}
+  }
+
+  return JSON.parse(str)
+}
+
+/**
+ * write
+ * Writes a JSON string from javascript object
+ *
+ * @param {Object} data - a javascript object to put into string
+ * @returns {String} - a JSON string
+ */
+export async function write (data) {
+  return JSON.stringify(data, null, '\t')
+}

--- a/src/flightcheck/parsers/json.js
+++ b/src/flightcheck/parsers/json.js
@@ -14,11 +14,6 @@
  * @returns {Object} - a javascript object of the JSON string
  */
 export async function read (str) {
-  // Test if it's an empty file (no real charactors)
-  if (!/\S/.test(str)) {
-    return {}
-  }
-
   return JSON.parse(str)
 }
 

--- a/test/flightcheck/index.js
+++ b/test/flightcheck/index.js
@@ -4,5 +4,7 @@
  */
 
 describe('flightcheck', () => {
+  require('./parsers')
+
   require('./issues')
 })

--- a/test/flightcheck/parsers/colon.js
+++ b/test/flightcheck/parsers/colon.js
@@ -1,0 +1,90 @@
+/**
+ * tests/flightcheck/parsers/colon.js
+ * Tests the ability to read and write from colon seperated files
+ */
+
+import chai from 'chai'
+
+import * as colon from '~/flightcheck/parsers/colon'
+
+const assert = chai.assert
+
+describe('colon', () => {
+  it('can read a simple file', async (done) => {
+    const obj = await colon.read(`
+      Source: vocal
+      Section: sound
+      Priority: optional
+      Maintainer: Nathan Dyer
+      Build-Depends: cmake (>= 2.8),
+                     debhelper (>= 8.0.0),
+                     libgee-0.8-dev,
+                     libgranite-dev,
+                     libgtk-3-dev (>= 3.14),
+                     valac (>= 0.18.1),
+                     libunity-dev,
+                     libnotify-dev,
+                     libxml2-dev,
+                     libgstreamer1.0-dev,
+                     libgstreamer-plugins-base1.0-dev,
+                     libclutter-gtk-1.0-dev,
+                     libclutter-1.0-dev,
+                     libclutter-gst-3.0-dev,
+                     libsqlite3-dev,
+                     libsoup2.4-dev,
+                     libwebkit2gtk-3.0-dev
+
+      Standards-Version: 3.9.3
+      Package: vocal
+      Architecture: any
+      Depends: \${misc:Depends}, \${shlibs:Depends}
+      Description: Vocal
+       Simple podcast client for the modern desktop.
+    `)
+
+    assert.equal(obj['Source'], 'vocal')
+    assert.isArray(obj['Build-Depends'])
+    assert.lengthOf(obj['Build-Depends'], 17)
+    assert.equal(obj['Build-Depends'][3], 'libgranite-dev')
+    assert.equal(obj['Maintainer'], 'Nathan Dyer')
+    assert.equal(obj['Depends'], '${misc:Depends}, ${shlibs:Depends}')
+    assert.equal(obj['Description'], 'Vocal\n       Simple podcast client for the modern desktop.')
+
+    done()
+  })
+
+  it('can write a simple file', async (done) => {
+    const str = await colon.write({
+      Source: 'vocal',
+      Section: 'sound',
+      Priority: 'optional',
+      Maintainer: 'Nathan Dyer',
+      'Build-Depends': ['cmake (>= 2.8)', 'debhelper (>= 8.0.0)', 'libgee-0.8-dev'],
+      'Standards-Version': '3.9.3',
+      Package: 'vocal',
+      Architecture: 'any',
+      Depends: '${misc:Depends}, ${shlibs:Depends}',
+      Description: 'Vocal\n Simple podcast client for the modern desktop.'
+    })
+
+    assert.equal(str, [
+      'Source: vocal',
+      'Section: sound',
+      'Priority: optional',
+      'Maintainer: Nathan Dyer',
+      'Build-Depends: cmake (>= 2.8),',
+      '               debhelper (>= 8.0.0),',
+      '               libgee-0.8-dev',
+      '',
+      'Standards-Version: 3.9.3',
+      'Package: vocal',
+      'Architecture: any',
+      'Depends: ${misc:Depends}, ${shlibs:Depends}',
+      'Description: Vocal',
+      ' Simple podcast client for the modern desktop.',
+      ''
+    ].join('\n'))
+
+    done()
+  })
+})

--- a/test/flightcheck/parsers/index.js
+++ b/test/flightcheck/parsers/index.js
@@ -1,0 +1,8 @@
+/**
+ * tests/flightcheck/parsers/index.js
+ * Entry for handling all flightcheck parsing tests
+ */
+
+describe('parse', () => {
+  require('./colon')
+})


### PR DESCRIPTION
This adds a very basic `File` class with automatic parsing support.

Added some basic parsers, nothing too fancy, except for the `colon` parser. I added a test for that one so you can see the result.

This class currently is not in use, but it will be when I redo the actual hook class (after #186).