### PR TITLE
Fixes crash when host has docker images without RepoTags

### DIFF
--- a/src/strongback/index.js
+++ b/src/strongback/index.js
@@ -88,7 +88,7 @@ function ensureImage () {
       if (err) return reject(err)
 
       const houstonImages = images.filter((image) => {
-        return (image.RepoTags.indexOf('houston:latest') !== -1)
+        return ((image.RepoTags || []).indexOf('houston:latest') !== -1)
       })
 
       if (houstonImages.length > 0) {


### PR DESCRIPTION
```
> Houston@0.2.6 strongback /home/simon/projects/houston
> node build/entry.js strongback

/home/simon/projects/houston/build/strongback/index.js:122
        return image.RepoTags.indexOf('houston:latest') !== -1;
                             ^

TypeError: Cannot read property 'indexOf' of null
    at /home/simon/projects/houston/build/strongback/index.js:122:30
    at Array.filter (native)
    at Object.callback (/home/simon/projects/houston/build/strongback/index.js:121:34)
    at /home/simon/projects/houston/node_modules/dockerode/lib/docker.js:312:10
    at Modem.buildPayload (/home/simon/projects/houston/node_modules/docker-modem/lib/modem.js:245:7)
    at IncomingMessage.<anonymous> (/home/simon/projects/houston/node_modules/docker-modem/lib/modem.js:204:14)
    at emitNone (events.js:91:20)
    at IncomingMessage.emit (events.js:185:7)
    at endReadableNT (_stream_readable.js:974:12)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```