### PR TITLE
Allow to disable aptly

### DIFF
--- a/src/flightcheck/pipes/Elementary/Aptly/index.js
+++ b/src/flightcheck/pipes/Elementary/Aptly/index.js
@@ -65,7 +65,7 @@ export default class ElementaryAptly extends Pipe {
 
     if (files.length < 1) return
 
-    if (!config.aptly) return this.log('debug', 'Elementary/Aptly/disabled.md')
+    if (!config.aptly || !config.aptly.url) return this.log('debug', 'Elementary/Aptly/disabled.md')
 
     const apphub = await this.require('AppHub')
 

--- a/src/houston/service/aptly.js
+++ b/src/houston/service/aptly.js
@@ -13,6 +13,19 @@ import Mistake from '~/lib/mistake'
 import request from '~/lib/request'
 
 /**
+ * ensureEnabled
+ * Ensures that aptly configuration is set
+ *
+ * @return {Void}
+ * @throws {Mistake} - if aptly is currently disabled
+ */
+function ensureEnabled () {
+  if (!config.aptly || !config.aptly.url) {
+    throw new Mistake(503, 'Aptly is currently disabled')
+  }
+}
+
+/**
  * upload
  * Uploads a package to aptly in review repository
  *
@@ -223,10 +236,4 @@ export function stable (pkg, dist) {
 
   return move(pkg, config.aptly.review, config.aptly.stable)
   .then(() => publish(config.aptly.stable, dist))
-}
-
-function ensureEnabled () {
-  if (!config.aptly || !config.aptly.url) {
-    throw new Mistake(503, 'Aptly is currently disabled')
-  }
 }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -70,7 +70,7 @@ try {
   .split('\n')[0]
 } catch (error) {}
 
-Object.assign(config, {
+config = _.merge(config, {
   houston: {
     root: path.resolve(__dirname, '../'),
     version: houstonPkg.version,
@@ -87,22 +87,19 @@ const dotConfig = dotNotation.toDot(config)
 const dotExample = dotNotation.toDot(example)
 const missingConfig = []
 
+// If any higher level attribute is set to false, don't consider it missing
 Object.keys(dotExample).forEach((key) => {
   if (dotConfig[key] != null) return
 
-  // If any higher level attribute is set to false, don't consider it missing
-  let falseAttribute = false
   const splitKey = key.split('.')
-  for (let keyI = 0; keyI < splitKey.length; keyI++) {
+
+  for (let keyI = 1; keyI < splitKey.length; keyI++) {
     const miniKey = splitKey.slice(0, keyI).join('.')
 
-    if (dotConfig[miniKey] != null && !dotConfig[miniKey]) {
-      falseAttribute = true
+    if (dotConfig[miniKey] == null || dotConfig[miniKey] !== false) {
+      missingConfig.push(key)
     }
   }
-  if (falseAttribute) return
-
-  missingConfig.push(key)
 })
 
 missingConfig.forEach((key) => {

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -46,14 +46,10 @@ describe('config', () => {
   })
 
   it('does now throw error if path is false', (done) => {
-    mock('../../config', Object.assign(require('../mocks/config'), {
-      github: false
-    }))
-    mock('../../config.example.js', {
-      github: {
-        setting: 'you need this for github settings'
-      }
-    })
+    const mockConfig = require('../mocks/config')
+    mockConfig['aptly'] = false
+
+    mock('../../config', mockConfig)
 
     assert.doesNotThrow(() => require('../../src/lib/config'), 'respects false attribute')
     done()


### PR DESCRIPTION
The old way to disable aptly was to set `config.aptly = false`. This doesn't work anymore since the startup script requires `config.aptly.*` to be set.

This PR allows to disable aptly by setting `config.aptly.url = null`.