### PR TITLE
add event emitter to pipe and pipeline

### DIFF
--- a/src/flightcheck/pipeline.js
+++ b/src/flightcheck/pipeline.js
@@ -197,10 +197,10 @@ export default class Pipeline extends events.EventEmitter {
 
     const pipe = new pipes[name](this)
 
-    pipe.on('start', () => this.emit('pipe:start', pipe))
-    pipe.on('error', (err) => this.emit('pipe:error', pipe, err))
-    pipe.on('finish', () => this.emit('pipe:finish', pipe))
-    pipe.on('log', (log) => this.emit('pipe:log', pipe, log))
+    pipe.on('start', (...args) => this.emit('pipe:start', pipe, ...args))
+    pipe.on('error', (...args) => this.emit('pipe:error', pipe, ...args))
+    pipe.on('finish', (...args) => this.emit('pipe:finish', pipe, ...args))
+    pipe.on('log', (...args) => this.emit('pipe:log', pipe, ...args))
 
     this.pipes.push(pipe)
     return pipe.run(...args)


### PR DESCRIPTION
This makes `Pipe` and `Pipeline` inherit the event emitter class, allowing greater insight into what is happening during the build. Currently there is nothing listening to these events, but it will come in handy with the message queue.

Pipe fires:
- `start`
- `error` with error object
- `finish`
- `log` with log object

Pipeline fires:
- all pipe events prefixed with `pipe:` and the pipe as first argument