### PR TITLE
fix eslint issues with updated upstream packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,15 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
+    "babel-eslint": "^6.1.2",
     "babel-plugin-webpack-alias": "^2.1.1",
-    "eslint": "2.10.2",
     "eslint-config-a-standard": "^1.0.6",
+    "eslint-config-standard": "^6.0.1",
     "eslint-plugin-ava": "^3.0.0",
+    "eslint-plugin-babel": "^3.3.0",
+    "eslint-plugin-promise": ">=1.0.8",
+    "eslint-plugin-standard": ">=1.3.1",
+    "eslint": "^3.6.0",
     "mock-require": "^1.2.1",
     "nock": "^7.7.2"
   },

--- a/src/lib/helpers/debian.js
+++ b/src/lib/helpers/debian.js
@@ -19,7 +19,7 @@ export function time (date) {
   if (typeof date === 'number') {
     date = new Date(date)
   }
-  if (!date instanceof Date) {
+  if (date instanceof !Date) {
     throw new Error('date is expected to be an instance of Date')
   }
 

--- a/test/flightcheck/parsers/colon.js
+++ b/test/flightcheck/parsers/colon.js
@@ -41,6 +41,7 @@ test('can read a file', async (t) => {
 
   t.is(one['Source'], 'vocal')
   t.is(one['Maintainer'], 'Nathan Dyer')
+  // eslint-disable-next-line no-template-curly-in-string
   t.is(one['Depends'], '${misc:Depends}, ${shlibs:Depends}')
   t.is(one['Description'], 'Vocal\n     Simple podcast client for the modern desktop.')
 
@@ -59,6 +60,7 @@ test('can write a file', async (t) => {
     'Standards-Version': '3.9.3',
     Package: 'vocal',
     Architecture: 'any',
+    // eslint-disable-next-line no-template-curly-in-string
     Depends: '${misc:Depends}, ${shlibs:Depends}',
     Description: 'Vocal\n Simple podcast client for the modern desktop.'
   })
@@ -75,6 +77,7 @@ test('can write a file', async (t) => {
     'Standards-Version: 3.9.3',
     'Package: vocal',
     'Architecture: any',
+    // eslint-disable-next-line no-template-curly-in-string
     'Depends: ${misc:Depends}, ${shlibs:Depends}',
     'Description: Vocal',
     ' Simple podcast client for the modern desktop.',


### PR DESCRIPTION
I changed the way a-standard linting works upstream, and because we are extending the package instead of using it normally, we have to include some other packages now. On the bright side, we are no longer using outdated linting packages.

There are a couple of new rules, but nothing too extensive. This PR includes fixes for the new rules.