### PR TITLE
use filters instead of global tree

### DIFF
--- a/src/flightcheck/pipes/Debian/Changelog/changelog.nun
+++ b/src/flightcheck/pipes/Debian/Changelog/changelog.nun
@@ -3,4 +3,4 @@
 {% for change in changes %}  * {{ change }}
 {% endfor %}
 
-{{ " " }}-- {{ author }} <{{ author }}@houston.elementary.io>  {{ helper.debian.time(date) }}
+{{ " " }}-- {{ author }} <{{ author }}@houston.elementary.io>  {{ date | debianTime }}

--- a/src/flightcheck/pipes/Liftoff/failure.md
+++ b/src/flightcheck/pipes/Liftoff/failure.md
@@ -4,7 +4,7 @@ Apphub failed to build with liftoff. Here is the log:
 
 ```
 {% if data != null %}
-{{ helper.lang.chop(data, 50) | safe }}
+{{ data | langChop(50) | safe }}
 {% else %}
 Unable to retrieve data
 {% endif %}

--- a/src/lib/render.js
+++ b/src/lib/render.js
@@ -17,8 +17,11 @@ const nun = nunjucks.configure(config.houston.root, {
   trimBlocks: true,
   lstripBlocks: true
 })
+
 nun.addGlobal('config', config)
-nun.addGlobal('helper', helpers)
+
+nun.addFilter('debianTime', helpers.debian.time)
+nun.addFilter('langChop', helpers.lang.chop)
 
 /**
  * Renders markdown


### PR DESCRIPTION
This fixes an issue with nunjucks erroring while trying to render files with functions. Apparently some update recently to nunjucks must have broken it as it used to work  :8ball:. 

Currently debian changelog pipe will fail all builds :(