### PR TITLE
Nav CSS Changes

### DIFF
--- a/src/houston/public/styles/houston.css
+++ b/src/houston/public/styles/houston.css
@@ -8,14 +8,14 @@
 ******/
 
 nav {
-    background-color: #403757;
+    background-color: #4d4267;
     color: #fff;
     fill: #fff;
     overflow-y: hidden;
 }
 
 nav .avatar {
-    border: 1px solid rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(0, 0, 0, 0.7);
     border-radius: 50%;
     box-shadow:
         inset 0 0 0 1px rgba(255, 255, 255, 0.05),
@@ -30,6 +30,8 @@ nav .avatar {
 }
 
 nav#secondary {
-    background-color: #524571;
+    background-color: #f5f5f5;
+    color: #333;
+    font-size: 14px;
     height: 48px;
 }


### PR DESCRIPTION
- Makes the nav color match the background color from elementary/developer
- Makes the secondary nav light instead of dark, opens up the page a bit I think
- Makes the secondary nav text size 14px instead of 16px
- Makes the avatar border a little darker so it doesn't look weird on the light background