### PR TITLE
make popovers into compact tooltips

### DIFF
--- a/src/houston/public/styles/dashboard.css
+++ b/src/houston/public/styles/dashboard.css
@@ -16,13 +16,12 @@
     color: #fff;
     height: 52px;
     position: relative;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     transition: box-shadow 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     width: 52px;
     will-change: box-shadow;
 }
 
-.fab:hover {
+.fab:hover:not(.busy) {
     box-shadow:
         0 0 2px rgba(0, 0, 0, 0.18),
         0 4px 8px rgba(0, 0, 0, 0.24);
@@ -30,12 +29,6 @@
 
 .fab.busy {
     background-color: #f9c440;
-}
-
-.fab.busy:hover {
-    box-shadow:
-        0 1px 3px rgba(0, 0, 0, 0.12),
-        0 1px 2px rgba(0, 0, 0, 0.24);
 }
 
 .fab.success {
@@ -54,6 +47,7 @@
     font-size: 28px;
     line-height: 52px;
     text-align: center;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     width: 52px;
 }
 
@@ -172,24 +166,25 @@
 }
 
 .repo .fab .popover-container .popover-content {
-    position: relative;
-    right: -50%;
-    bottom: 30px;
-    width: 200px;
-    z-index: 2;
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    border-radius: 5px;
-    background: white;
-    color: #333;
-    background-clip: content-box;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-    text-align: left;
+    background: rgba(51, 51, 51, 0.9);
+    border-radius: 3px;
+    bottom: 50px;
+    color: #fff;
+    box-shadow:
+        0 1px 3px rgba(0, 0, 0, 0.12),
+        0 1px 2px rgba(0, 0, 0, 0.24);
     font-size: 14px;
     font-family: 'Open Sans', 'Droid Sans', Helvetica, sans-serif;
+    margin-right: 8px;
     opacity: 0;
-    visibility: hidden;
+    padding: 6px 12px;
     pointer-events: none;
+    position: relative;
+    right: -50%;
+    text-align: left;
+    visibility: hidden;
     transition: visibility 0s 250ms, opacity 250ms;
+    z-index: 999;
 }
 
 .repo .fab .popover-container .popover-content::before,
@@ -198,20 +193,15 @@
     display: block;
     position: absolute;
     left: 50%;
-    margin-left: -5px;
+    margin-left: -1px;
     width: 0;
     height: 0;
-    border: 10px outset transparent;
-}
-
-.repo .fab .popover-container .popover-content::before {
-    bottom: -20px;
-    border-top: 10px solid rgba(0, 0, 0, 0.2);
+    border: 6px outset transparent;
 }
 
 .repo .fab .popover-container .popover-content::after {
-    bottom: -18px;
-    border-top: 10px solid white;
+    bottom: -12px;
+    border-top: 6px solid rgba(51, 51, 51, 0.9);
 }
 
 .repo .fab:hover .popover-container .popover-content {
@@ -219,10 +209,6 @@
     pointer-events: auto;
     opacity: 1;
     transition: opacity 250ms;
-}
-
-.repo .fab .popover-container .popover-content p {
-    text-align: center;
 }
 
 .repo .fab .popover-container .popover-content strong {
@@ -270,25 +256,13 @@
     border: 0;
 }
 
-.repo .fab .popover-container .popover-content {
-    z-index: 999;
-    margin-right: 8px;
-    bottom: 50px;
-    width: auto;
-    min-width: 200px;
-}
-
 .repo .fab .popover-container .popover-content h2 {
     text-align: center;
     font-size: 18px;
-    margin: 12px;
 }
 
 .repo .fab .popover-container .popover-content h3 {
     font-size: 16px;
-    margin: 12px;
-}
-
-.repo .fab .popover-container .popover-content p {
-    margin: 12px;
+    margin: 0 0 6px;
+    opacity: 1;
 }

--- a/src/houston/public/styles/dashboard.css
+++ b/src/houston/public/styles/dashboard.css
@@ -189,7 +189,6 @@
     border-top: 6px solid rgba(51, 51, 51, 0.9);
 }
 
-.repo .button:hover .popover-container .popover-content,
 .repo .fab:hover .popover-container .popover-content {
     visibility: visible;
     pointer-events: auto;

--- a/src/houston/public/styles/dashboard.css
+++ b/src/houston/public/styles/dashboard.css
@@ -146,11 +146,11 @@
 .repo .popover-container {
     position: absolute;
     right: 50%;
-    bottom: -9px;
+    bottom: -12px;
     pointer-events: none;
 }
 
-.repo .fab .popover-container .popover-content {
+.repo .popover-container .popover-content {
     background: rgba(51, 51, 51, 0.9);
     border-radius: 3px;
     bottom: 50px;
@@ -184,7 +184,7 @@
     border: 6px outset transparent;
 }
 
-.repo .fab .popover-container .popover-content::after {
+.repo .popover-container .popover-content::after {
     bottom: -12px;
     border-top: 6px solid rgba(51, 51, 51, 0.9);
 }
@@ -197,7 +197,7 @@
     transition: opacity 250ms;
 }
 
-.repo .fab .popover-container .popover-content strong {
+.repo .popover-container .popover-content strong {
     display: inline-block;
     margin: 15px;
     margin-bottom: 10px;
@@ -242,7 +242,7 @@
     border: 0;
 }
 
-.repo .fab .popover-container .popover-content h2 {
+.repo .popover-container .popover-content h2 {
     text-align: center;
     font-size: 18px;
 }

--- a/src/houston/views/partials/review.jade
+++ b/src/houston/views/partials/review.jade
@@ -3,7 +3,7 @@ a(href="project/" + cycle.name + "/review/no")
     i.fa.fa-times
     div.popover-container
       div.popover-content
-        h2 Request Changes
+        h3 Request Changes
         p #{cycle.project.name} needs fixing
 
 a(href="project/" + cycle.name + "/review/yes")
@@ -11,5 +11,5 @@ a(href="project/" + cycle.name + "/review/yes")
     i.fa.fa-check
     div.popover-container
       div.popover-content
-        h2 Approve
+        h3 Approve
         p Release #{cycle.project.name} into AppCenter

--- a/src/houston/views/partials/status/error.jade
+++ b/src/houston/views/partials/status/error.jade
@@ -3,5 +3,5 @@ a(href="/project/" + project.name + "/cycle")
     i.fa.fa-exclamation-circle
     div.popover-container
       div.popover-content
-        h2 Error Encountered Processing #{project.name}.
+        h3 Error Encountered Processing #{project.name}.
         p This is most likely a problem with this website.

--- a/src/houston/views/partials/status/fail.jade
+++ b/src/houston/views/partials/status/fail.jade
@@ -3,5 +3,5 @@ a(href="https://github.com/" + project.github.fullName + "/issues?q=is%3Aissue+i
     i.fa.fa-exclamation-triangle
     div.popover-container
       div.popover-content
-        h2 #{project.name} Has Failed The Release Proccess
+        h3 #{project.name} Has Issues That Must Be Resolved
         p No worries though, we have submitted detailed reports on GitHub for you.

--- a/src/houston/views/partials/status/finish.jade
+++ b/src/houston/views/partials/status/finish.jade
@@ -2,5 +2,5 @@ div.fab.success
   i.fa.fa-rocket
   div.popover-container
     div.popover-content
-      h2 #{project.name} is Available on AppCenter.
+      h3 #{project.name} is Available on AppCenter.
       p Make a new release on GitHub to submit a new version.

--- a/src/houston/views/partials/status/init.jade
+++ b/src/houston/views/partials/status/init.jade
@@ -3,5 +3,5 @@ a(href="https://github.com/" + project.github.fullName + "/releases/new", target
     i.fa.fa-tag
     div.popover-container
       div.popover-content
-        h2 Release #{project.name} on GitHub
+        h3 Release #{project.name} on GitHub
         p Make sure to use a Semantic Version Number like 1.0.0

--- a/src/houston/views/partials/status/new.jade
+++ b/src/houston/views/partials/status/new.jade
@@ -3,5 +3,5 @@ a(href="/project/" + project.name + "/init")
     i.fa.fa-check
     div.popover-container
       div.popover-content
-        h2 New Project
+        h3 New Project
         p One click and #{project.name} will be ready for AppCenter.

--- a/src/houston/views/partials/status/queue.jade
+++ b/src/houston/views/partials/status/queue.jade
@@ -2,5 +2,5 @@ div.fab.busy
   i.fa.fa-clock-o
   div.popover-container
     div.popover-content
-      h2 Waiting for Space
+      h3 Waiting for Space
       p #{project.name} #{project.version} is in line for testing.

--- a/src/houston/views/partials/status/review.jade
+++ b/src/houston/views/partials/status/review.jade
@@ -2,5 +2,5 @@ div.fab.busy
   i.fa.fa-user
   div.popover-container
     div.popover-content
-      h2 #{project.name} is Being Tested by a Human
+      h3 #{project.name} is Being Tested by a Human
       p Sit back and have a drink. We'll let you know if anything is amiss.

--- a/src/houston/views/partials/status/run.jade
+++ b/src/houston/views/partials/status/run.jade
@@ -2,5 +2,5 @@ div.fab.busy
   i.fa.fa-refresh
   div.popover-container
     div.popover-content
-      h2 Some Checks Haven’t Completed Yet
+      h3 Some Checks Haven’t Completed Yet
       p #{project.name} is being built and automatically tested. 

--- a/src/houston/views/partials/status/standby.jade
+++ b/src/houston/views/partials/status/standby.jade
@@ -5,8 +5,4 @@ a(href="/project/" + project.name + "/cycle")
     i.fa.fa-arrow-up
     div.popover-container
       div.popover-content
-<<<<<<< HEAD
-        h3 Submit for Review
-=======
->>>>>>> master
         p Once #{project.name} has been reviewed it will automatically be published in AppCenter.

--- a/src/houston/views/partials/status/standby.jade
+++ b/src/houston/views/partials/status/standby.jade
@@ -3,5 +3,5 @@ a(href="/project/" + project.name + "/cycle")
     i.fa.fa-arrow-up
     div.popover-container
       div.popover-content
-        h2 Submit for Review
+        h3 Submit for Review
         p Once #{project.name} has been reviewed it will automatically be published in AppCenter.


### PR DESCRIPTION
![screenshot from 2016-10-17 12 06 33](https://cloud.githubusercontent.com/assets/7277719/19451468/35663424-9462-11e6-87d1-e4f4c9ecc449.png)

- clean up some duplicate CSS styles
- makes big popovers into compact tooltips. Since these are informational and non-interactive it makes more sense to use the tooltip metaphor.
- Change "Failed" text to "Issues That Must be Resolved". Little less brutal and indicates that we can fix this :)