### PR TITLE
Center View Switching

### DIFF
--- a/src/houston/views/layout/main.jade
+++ b/src/houston/views/layout/main.jade
@@ -31,11 +31,16 @@ html
         div.nav-content
           ul
             block actions
-            li: a(href="/dashboard") Dashboard
-            li: a(href="https://github.com/integration/appcenter", target="_blank") Add App…
+            li: a(href="https://github.com/integration/appcenter", target="_blank") Manage Apps…
 
-            if policy.ifRole(user, 'review')
-              li: a(href="/reviews") Reviews
+          if policy.ifRole(user, 'review')
+          ul
+            li: a(href="/dashboard")
+              i.fa.fa-bar-chart
+              span  Dashboard
+            li: a(href="/reviews")
+              i.fa.fa-check-square-o
+              span  Reviews
 
           ul.right
             // We can re/move this after beta is over


### PR DESCRIPTION
- Change "Add Apps..." to "Manage Apps..." since you add and remove from this view
- Move View Switching items to the center and give them neato icons
- Since app management is now done externally, the only time you need to switch views is when you have permissions to do reviews. So, only show the Dashboard item if you have review permissions.

The Double space in the view switcher items is intentional. It puts space between the icon and the word