### PR TITLE
center view switcher

### DIFF
--- a/src/houston/public/styles/houston.css
+++ b/src/houston/public/styles/houston.css
@@ -35,3 +35,19 @@ nav#secondary {
     font-size: 14px;
     height: 48px;
 }
+
+@media only screen and (min-width: 1024px) {
+    nav#secondary ul {
+        display: flex;
+        flex: 0 0 33%;
+        justify-content: center;
+    }
+
+    nav#secondary ul:first-child {
+        justify-content: flex-start;
+    }
+
+    nav#secondary ul:last-child {
+        justify-content: flex-end;
+    }
+}

--- a/src/houston/views/layout/main.jade
+++ b/src/houston/views/layout/main.jade
@@ -14,7 +14,7 @@ html
     title #{title} &sdot; elementary
 
   body
-    nav.nav
+    nav
       div.nav-content
         ul
           li: a(href="https://elementary.io", class="logomark")
@@ -27,7 +27,7 @@ html
           li: a(href="https://elementary.io/get-involved") Get Involved
 
     if user && !hideUser
-      nav.nav#secondary
+      nav#secondary
         div.nav-content
           ul
             block actions
@@ -42,7 +42,7 @@ html
               i.fa.fa-check-square-o
               span  Reviews
 
-          ul.right
+          ul
             // We can re/move this after beta is over
             if config.houston.version.split('.')[0] < 1
               li: a(href="https://github.com/elementary/houston/issues/new", target="_blank") Send Feedback…


### PR DESCRIPTION
Fixes #279 
- Remove dead style classes from `main.jade`
- Use flex magic to center the view switcher when the display is wide enough for that