### PR TITLE
fix github git url being weird

### DIFF
--- a/src/flightcheck/interfaces/houston.js
+++ b/src/flightcheck/interfaces/houston.js
@@ -29,12 +29,19 @@ worker.register('release', async (param) => {
 
   let pipeline = null
   try {
-    param.changelog = param.changelog.map((c) => {
+    const changelog = param.changelog.map((c) => {
       c['changes'] = c['changelog']
       return c
     })
 
-    pipeline = new Pipeline(param)
+    pipeline = new Pipeline({
+      repo: param.repo,
+      tag: param.tag,
+      name: param.name,
+      source: 'github',
+      changelog,
+      auth: param.auth
+    })
   } catch (err) {
     log.error(`Flightcheck received an error while trying to create Pipeline for ${param.id}`)
     log.error(err)

--- a/src/service/github.js
+++ b/src/service/github.js
@@ -180,6 +180,13 @@ export function castProject (project, installation) {
   const owner = service.nameify(project.owner.login)
   const repo = service.nameify(project.name)
 
+  // Why GitHub mixes different urls depending on API call I don't know
+  if (project.git_url.substr(0, 6) === 'git://') {
+    project.git_url = `https://${project.git_url.substr(6)}`
+  } else if (project.git_url.substr(0, 4) === 'git:') {
+    project.git_url = `https://${project.git_url.substr(4)}`
+  }
+
   return {
     name: `com.github.${owner}.${repo}`,
     repo: project.git_url,

--- a/test/service/github.js
+++ b/test/service/github.js
@@ -170,7 +170,7 @@ test('Can get list of repos', async (t) => {
 
   t.is(typeof one, 'object')
   t.is(one[0].name, 'com.github.elementary.test1')
-  t.is(one[0].repo, 'git:github.com/elementary/test1.git')
+  t.is(one[0].repo, 'https://github.com/elementary/test1.git')
   t.is(one[0].github.id, 1)
   t.is(typeof one[0].github.integration, 'undefined')
 })


### PR DESCRIPTION
because GitHub sends weird git urls like `git:github.com/elementary/vocal.git` which can't be used ~by git~ without more configuration :shrug: