### PR TITLE
Change dashboard width

### DIFF
--- a/src/houston/public/styles/dashboard.css
+++ b/src/houston/public/styles/dashboard.css
@@ -128,14 +128,13 @@
     margin: 10px;
 }
 
-@media only screen and (min-width: 500px) {
+@media only screen and (min-width: 900px) {
     .repo {
         align-items: center;
         flex-direction: row;
         justify-content: space-between;
         margin: auto;
-        max-width: 600px;
-        min-width: 400px;
+        max-width: 900px;
         text-align: left;
         width: 80%;
     }


### PR DESCRIPTION
Changes repo collapse width to something larger, avoiding weird flexbox wrapping like so:
![screenshot from 2017-01-04 15 51 36](https://cloud.githubusercontent.com/assets/3385679/21662440/e5a5a6e0-d296-11e6-9acb-4a1cf41a6e37.png)
