### PR TITLE
add basic beta invite page

### DIFF
--- a/src/houston/controller/admin/beta.js
+++ b/src/houston/controller/admin/beta.js
@@ -1,0 +1,28 @@
+/**
+ * houston/controller/admin/index.js
+ * Handles beta administration
+ *
+ * @exports {Object} - Koa router objects
+ */
+
+import Router from 'koa-router'
+
+import User from 'lib/database/user'
+
+const route = new Router()
+
+/**
+ * GET /admin/beta
+ * Returns a list of people waiting to get into beta
+ */
+route.get('/beta', async (ctx, next) => {
+  const users = await User.find({
+    right: 'USER',
+    'notify.beta': true
+  })
+  .sort('date.joined')
+
+  return ctx.render('admin/beta', { users })
+})
+
+export default route

--- a/src/houston/controller/admin/index.js
+++ b/src/houston/controller/admin/index.js
@@ -1,0 +1,22 @@
+/**
+ * houston/controller/admin/index.js
+ * Handles all admin pages
+ *
+ * @exports {Object} - Koa router objects
+ */
+
+import Router from 'koa-router'
+
+import * as policy from 'houston/policy'
+
+import beta from './beta'
+
+const route = new Router({
+  prefix: '/admin'
+})
+
+route.use(policy.isRole('ADMIN'), policy.isAgreement)
+
+route.use(beta.routes(), beta.allowedMethods())
+
+export default route

--- a/src/houston/controller/index.js
+++ b/src/houston/controller/index.js
@@ -7,6 +7,7 @@
 
 import Router from 'koa-router'
 
+import admin from './admin'
 import api from './api'
 import hooks from './hook'
 
@@ -16,6 +17,7 @@ import project from './project'
 
 const route = new Router()
 
+route.use(admin.routes(), admin.allowedMethods())
 route.use(api.routes(), api.allowedMethods())
 route.use(hooks.routes(), hooks.allowedMethods())
 

--- a/src/houston/views/admin/beta.pug
+++ b/src/houston/views/admin/beta.pug
@@ -1,0 +1,19 @@
+extends /layout/main
+
+block head
+  link(rel="stylesheet", type="text/css", media="all", href="https://elementary.io/styles/team.css")
+
+block body
+  if users.length === 0
+    section.grid.alert: div.half
+      h3 Nobody is interested.
+      p Currently, nobody is on the wait list for beta invites.
+  else
+    div.grid
+      div.whole
+        div.team-directory
+          each u in users
+            div.member
+              div.member_photo(style="background-image: url(\"" + u.avatar + "\")")
+              h5.member_name= u.username
+              span.member_title= u.email


### PR DESCRIPTION
Adds a page at `/admin/beta` to view everyone who is waiting for a beta invite.
CSS is reused from the [team page](https://elementary.io/team).

