### PR TITLE
add database cache of github projects for user

### DIFF
--- a/src/houston/controller/dashboard.js
+++ b/src/houston/controller/dashboard.js
@@ -31,7 +31,7 @@ route.get('', (ctx) => {
  * Shows all projects
  */
 route.get('/dashboard', policy.isRole('BETA'), policy.isAgreement, async (ctx, next) => {
-  const githubProjects = await github.getRepos(ctx.state.user.github.access)
+  const githubProjects = await github.getReposForUser(ctx.state.user)
   .map((repo) => repo.github.id)
 
   const databaseProjects = await Project.find({

--- a/src/lib/database/user.js
+++ b/src/lib/database/user.js
@@ -23,6 +23,8 @@ const AGREEMENTDATE = new Date(2017, 0, 13)
  * @property {String} github.id - github account id
  * @property {String} github.acceses - github oauth access code
  * @property {String} github.refresh - github oauth refresh code
+ * @property {Date} github.cache - Last time GitHub cache was updated
+ * @property {Object} github.projects - A cache of GitHub projects the user has
  *
  * @property {String} right - user's permission scheme
  * @property {Object} notify - boolean keys for notifications
@@ -45,7 +47,10 @@ export const schema = new db.Schema({
   github: {
     id: String,
     access: String,
-    refresh: String
+    refresh: String,
+
+    cache: Date,
+    projects: Object
   },
 
   right: {

--- a/src/service/github.js
+++ b/src/service/github.js
@@ -13,6 +13,7 @@
  * @exports {Function} generateToken - Generates GitHub authentication token
  * @exports {Function} getRepo - Fetches a repository by GitHub ID
  * @exports {Function} getRepos - Fetches all repos the token has access to
+ * @exports {Function} getReposForUser - Fetches all repos for a given User
  * @exports {Function} getReleases - Fetches all releases a repo has
  * @exports {Function} getPermission - Checks callaborator status on repository
  * @exports {Function} getLabel - Returns GitHub label for repository
@@ -34,8 +35,12 @@ import * as error from 'lib/error/service'
 import * as service from './index'
 import config from 'lib/config'
 import Log from 'lib/log'
+import User from 'lib/database/user'
 
 const log = new Log('service:github')
+
+// Cache GitHub user repos for 12 hours
+const GITHUB_CACHE_TIME = 12 * 60 * 60 * 60 * 1000
 
 const api = domain('https://api.github.com')
 .use((req) => {
@@ -302,29 +307,49 @@ export function getRepo (owner: string, repo: string, token: string): Promise<Ob
 }
 
 /**
- * getRepos
- * Fetches all repos the token has access to
+ * getReposForUser
+ * Fetches all repos for a given User
  *
  * @see https://developer.github.com/v3/repos/#list-user-repositories
  *
- * @param {String} token - GitHub authentication token
+ * @param {User} user - User to find repositories for
  * @param {String} [sort] - what to sort the repos by
  *
  * @async
  * @throws {GitHubError} - on an error
  * @returns {Object}[] - a list of mapped GitHub projects
  */
-export function getRepos (token: string, sort: string = 'pushed'): Promise<Array<Object>> {
+export async function getReposForUser (user: User, sort: string = 'pushed'): Promise<Array<Object>> {
+  // Check user projects cache date
+  if (user.github != null && user.github.cache != null) {
+    if (moment().diff(user.github.cache) <= GITHUB_CACHE_TIME) {
+      if (user.github.projects != null && user.github.projects.length > 0) {
+        return user.github.projects
+      }
+    }
+  }
+
+  if (user.github.access == null) {
+    throw new error.ServiceError('GitHub', 'Unable to grab repositories for non GitHub user')
+  }
+
   const req = api
   .get('/user/repos')
-  .set('Authorization', `token ${token}`)
+  .set('Authorization', `token ${user.github.access}`)
   .query({ sort })
 
-  return pagination(req)
+  const projects = await pagination(req)
   .then((res) => res.body.map((project) => castProject(project)))
   .catch((err, res) => {
     throw errorCheck(err, res)
   })
+
+  await user.update({
+    'github.cache': new Date(),
+    'github.projects': projects
+  })
+
+  return projects
 }
 
 /**

--- a/test/lib/database/fixtures/user.js
+++ b/test/lib/database/fixtures/user.js
@@ -1,0 +1,47 @@
+/**
+ * test/lib/database/fixtures/user.js
+ * Some fixture data for a database User
+ *
+ * @exports {Function} mockUser - Mocks a User object
+ * @exports {Object} user - a single User object
+ */
+
+import _ from 'lodash'
+
+/**
+ * mockUser
+ * Some fixture data for a database User
+ *
+ * @param {Object} def - default values for a User
+ * @return {Object} - a mocked User object
+ */
+export function mockUser (def = {}) {
+  return _.merge({
+    username: 'test',
+    email: 'test@test.com',
+    avatar: null,
+
+    github: {
+      id: '123456',
+      access: 'access',
+      refresh: null,
+
+      cache: null,
+      projects: null
+    },
+
+    right: 'USER',
+    notify: {
+      beta: false
+    },
+
+    date: {
+      joined: new Date(),
+      visited: new Date()
+    },
+
+    projects: []
+  }, def)
+}
+
+export const user = mockUser()

--- a/test/service/github.js
+++ b/test/service/github.js
@@ -12,6 +12,7 @@ import nock from 'nock'
 import path from 'path'
 import test from 'ava'
 
+import { user as mockedUser } from 'test/lib/database/fixtures/user'
 import * as fixture from './fixtures/github'
 import alias from 'root/.alias'
 import mockConfig from 'test/fixtures/config'
@@ -25,6 +26,13 @@ const override = {
   }
 }
 
+mock(path.resolve(alias.resolve.alias['root'], 'config.js'), _.merge(mockConfig, override))
+
+const config = require(path.resolve(alias.resolve.alias['lib'], 'config')).default
+const db = require(path.resolve(alias.resolve.alias['lib'], 'database', 'connection.js')).default
+const User = require(path.resolve(alias.resolve.alias['lib'], 'database', 'user')).default
+const github = require(path.resolve(alias.resolve.alias['service'], 'github'))
+
 test.before((t) => {
   // This will capture any incoming data and put it to a file.
   // Use it for verifying we are testing real data.
@@ -35,21 +43,14 @@ test.before((t) => {
   // })
 
   nock.disableNetConnect() // Disables all real HTTP requests
+  db.connect(config.database)
 })
 
-test.beforeEach((t) => {
-  mock(path.resolve(alias.resolve.alias['root'], 'config.js'), _.merge(mockConfig, override))
-
-  t.context.config = require(path.resolve(alias.resolve.alias['lib'], 'config')).default
-  t.context.github = require(path.resolve(alias.resolve.alias['service'], 'github'))
-
-  // A note to the smart people. Don't use nock cleanAll() here.
+test.after((t) => {
+  db.connection.close()
 })
 
 test('Can generate an accurate JWT', async (t) => {
-  const config = t.context.config
-  const github = t.context.github
-
   const verify = (token) => new Promise((resolve, reject) => {
     fs.readFile(publicKey, (err, key) => {
       if (err) return reject(err)
@@ -83,8 +84,6 @@ test('Can generate an accurate JWT', async (t) => {
 })
 
 test('Can generate an accurate token', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -102,8 +101,6 @@ test('Can generate an accurate token', async (t) => {
 })
 
 test('Uses token cache', async (t) => {
-  const github = t.context.github
-
   // NOTE: we only mock each endpoint ONCE. if you get to this point due to an
   // 'Unable to generate authentication token' it's most likely because the
   // cache failed and we are trying to connect to GitHub again.
@@ -148,8 +145,6 @@ test('Uses token cache', async (t) => {
 })
 
 test('Can get single repo', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -163,9 +158,7 @@ test('Can get single repo', async (t) => {
   t.is(one.name, 'com.github.elementary.test')
 })
 
-test('Can get list of repos', async (t) => {
-  const github = t.context.github
-
+test('Can get list of repos for user', async (t) => {
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -174,7 +167,8 @@ test('Can get list of repos', async (t) => {
   .query({ sort: 'pushed', page: 1 })
   .reply(200, fixture.repos, fixture.header)
 
-  const one = await github.getRepos('testingToken')
+  const user = await User.create(mockedUser)
+  const one = await github.getReposForUser(user)
 
   t.is(typeof one, 'object')
   t.is(one[0].name, 'com.github.elementary.test1')
@@ -183,9 +177,49 @@ test('Can get list of repos', async (t) => {
   t.is(typeof one[0].github.integration, 'undefined')
 })
 
-test('Can get list of releases', async (t) => {
-  const github = t.context.github
+test('getReposForUser updates user cache', async (t) => {
+  nock('https://api.github.com:443', { encodedQueryparams: true })
+  .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
+  .replyContentLength()
+  .replyDate()
+  .get('/user/repos')
+  .query({ sort: 'pushed', page: 1 })
+  .reply(200, fixture.repos, fixture.header)
 
+  const user = await User.create(mockedUser)
+  const one = await github.getReposForUser(user)
+  const updatedUser = await User.findById(user._id)
+
+  t.not(updatedUser.github.cache, user.github.cache)
+  t.is(updatedUser.github.projects.length, one.length)
+})
+
+test('getReposForUser uses user cache of projects', async (t) => {
+  nock('https://api.github.com:443', { encodedQueryparams: true })
+  .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
+  .replyContentLength()
+  .replyDate()
+  .get('/user/repos')
+  .query({ sort: 'pushed', page: 1 })
+  .reply(200, fixture.repos, fixture.header)
+
+  const user = await User.create(mockedUser)
+
+  const one = await github.getReposForUser(user)
+  const two = await User.findById(user._id)
+
+  t.not(two.github.cache, user.github.cache)
+  t.is(two.github.projects.length, one.length)
+
+  const three = await github.getReposForUser(two)
+  const four = await User.findById(user._id)
+
+  t.deepEqual(four.github.cache, two.github.cache)
+  t.is(four.github.projects.length, three.length)
+  t.deepEqual(four.github.projects, three)
+})
+
+test('Can get list of releases', async (t) => {
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -203,8 +237,6 @@ test('Can get list of releases', async (t) => {
 })
 
 test('Can get a release by way of tag', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -221,8 +253,6 @@ test('Can get a release by way of tag', async (t) => {
 })
 
 test('Can get accurate permissions', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryParams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -247,8 +277,6 @@ test('Can get accurate permissions', async (t) => {
 })
 
 test('Can get a single label', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -267,8 +295,6 @@ test('Can get a single label', async (t) => {
 })
 
 test('Can get release assets', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .replyContentLength()
@@ -315,8 +341,6 @@ test('Can get release assets', async (t) => {
 })
 
 test('Can post a label', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryParams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .matchHeader('Authorization', 'token testToken')
@@ -343,8 +367,6 @@ test('Can post a label', async (t) => {
 })
 
 test('Can post an issue', async (t) => {
-  const github = t.context.github
-
   nock('https://api.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .matchHeader('Authorization', 'token testToken')
@@ -410,8 +432,6 @@ test('Can post an issue', async (t) => {
 })
 
 test('Can post a file', async (t) => {
-  const github = t.context.github
-
   nock('https://uploads.github.com:443', { encodedQueryparams: true })
   .matchHeader('Accept', 'application/vnd.github.machine-man-preview+json')
   .matchHeader('Authorization', 'token testToken')


### PR DESCRIPTION
Fixes #248, although I wouldn't consider it a permanent solution.

Basicly we store the projects the user has access to in the database, and if it's less than 12 hours old we use that instead of making another API call to GitHub. This makes it so after adding a package, there is a chance of a 12 hour delay before you can see it.

Future updates:
- Check GitHub header for updates
- Use something faster than the database, that is also shared between instances
- Impliment for all third-party API calls
- Add endpoint to bypass cache