### PR TITLE
Change default GitHub issue label to AppCenter

### DIFF
--- a/src/flightcheck/pipes/AppHub/index.js
+++ b/src/flightcheck/pipes/AppHub/index.js
@@ -31,7 +31,7 @@ export default class AppHub extends Pipe {
     this.data = {
       log: {
         enabled: true,
-        label: 'AppHub',
+        label: 'AppCenter',
         color: '3a416f',
         level: 'warn'
       },

--- a/src/flightcheck/pipes/AppHub/parse.md
+++ b/src/flightcheck/pipes/AppHub/parse.md
@@ -12,7 +12,7 @@ If you need a short refresher on JSON, here is a simple example file:
 ```
 {
   "log": {
-    "label": "AppHub"
+    "label": "AppCenter"
   }
 }
 ```


### PR DESCRIPTION
Fixes #380

There is still _a lot_ of code with references to AppHub that need to be changed. But one step at a time.