### PR TITLE
Refuel

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -17,3 +17,5 @@ module.name_mapper='houston/\(.*\)'->'<PROJECT_ROOT>/src/houston/\1'
 module.name_mapper='lib/\(.*\)'->'<PROJECT_ROOT>/src/lib/\1'
 module.name_mapper='service/\(.*\)'->'<PROJECT_ROOT>/src/service/\1'
 module.name_mapper='test/\(.*\)'->'<PROJECT_ROOT>/test/\1'
+
+suppress_comment= \\(.\\|\n\\)*\\FLOW

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "start": "node build/entry.js",
     "flightcheck": "node build/entry.js flightcheck",
     "houston": "node build/entry.js houston",
+    "refuel": "node build/entry.js refuel",
     "telemetry": "node build/entry.js telemetry",
     "build": "gulp build",
     "build:watch": "gulp watch",

--- a/src/entry.js
+++ b/src/entry.js
@@ -40,6 +40,15 @@ program
   })
 
 program
+  .command('refuel')
+  .description('starts the process for updating the stable repository')
+  .action((opts) => {
+    const refuel = require('./refuel')
+
+    refuel.start()
+  })
+
+program
   .command('telemetry')
   .description('starts nginx syslog server for download statistics')
   .option('-p, --port <port>', 'Port to listen on', config.telemetry.port)

--- a/src/refuel/index.js
+++ b/src/refuel/index.js
@@ -46,6 +46,7 @@ export function start () {
  * @returns {Void}
  */
 export function stop () {
+  // FLOW disable next line due to null checks
   clearInterval(interval)
   interval = null
 }

--- a/src/refuel/index.js
+++ b/src/refuel/index.js
@@ -1,0 +1,51 @@
+/**
+ * refuel/index.js
+ * Updates repository every 15 minutes
+ * @flow
+ *
+ * @exports {Number} delay - Delay to run function
+ * @exports {Function} start - Starts timer for updating repository
+ * @exports {Function} stop - Stops the timer
+ */
+
+import { publish } from 'service/aptly'
+import config from 'lib/config'
+import Log from 'lib/log'
+
+export const delay = 15 * 60 * 1000 // Run every 15 minutes
+
+const log = new Log('refuel')
+let interval = null
+
+/**
+ * run
+ * Starts timer for updating repository
+ *
+ * @returns {Void}
+ */
+export function start () {
+  log.debug('Starting interval')
+
+  interval = setInterval(() => {
+    log.debug('Updating repository')
+
+    try {
+      publish(config.aptly.stable)
+    } catch (err) {
+      log.error('Unable to publish repository', err)
+    }
+
+    start()
+  }, delay)
+}
+
+/**
+ * stop
+ * Stops the timer for updating repository
+ *
+ * @returns {Void}
+ */
+export function stop () {
+  clearInterval(interval)
+  interval = null
+}


### PR DESCRIPTION
This adds another process to houston that just updates the repository every 15 minutes. This should fix the stale appstream issues we have been having.

Should be merged after #402 