### PR TITLE
update database aggregates to fix appcenter banner

### DIFF
--- a/src/houston/controller/api/list.js
+++ b/src/houston/controller/api/list.js
@@ -14,6 +14,30 @@ const route = new Router({
 })
 
 /**
+ * GET /api/newest
+ * Finds the newest _first_ published project
+ * DEPRECATED: 05/06/2017 use /api/newest/project endpoint instead
+ */
+route.get('/', async (ctx) => {
+  const projects = await Project.aggregate([
+    { $unwind: '$releases' },
+    { $match: {
+      'releases._status': 'DEFER',
+      'releases.date.published': { $exists: true }
+    }},
+    { $sort: { 'releases.date.published': 1 } },
+    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
+    { $sort: { 'release.date.published': -1 } },
+    { $limit: 10 }
+  ])
+
+  ctx.status = 200
+  ctx.body = { data: projects.map((p) => p.name) }
+
+  return
+})
+
+/**
  * GET /api/newest/release
  * Finds the newest released project
  */

--- a/src/houston/controller/api/list.js
+++ b/src/houston/controller/api/list.js
@@ -25,8 +25,8 @@ route.get('/release', async (ctx) => {
       'releases.date.published': { $exists: true }
     }},
     { $sort: { 'releases.date.published': -1 } },
-    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'released': { $first: '$releases.date.published' } } },
-    { $sort: { 'released.date.published': -1 } },
+    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
+    { $sort: { 'release.date.published': -1 } },
     { $limit: 10 }
   ])
 

--- a/src/houston/controller/api/list.js
+++ b/src/houston/controller/api/list.js
@@ -48,7 +48,8 @@ route.get('/project', async (ctx) => {
       'releases.date.published': { $exists: true }
     }},
     { $sort: { 'releases.date.published': 1 } },
-    { $group: { _id: '$_id', 'name': { $first: '$name' } } },
+    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
+    { $sort: { 'release.date.published': -1 } },
     { $limit: 10 }
   ])
 

--- a/src/houston/controller/api/list.js
+++ b/src/houston/controller/api/list.js
@@ -9,13 +9,15 @@ import Router from 'koa-router'
 
 import Project from 'lib/database/project'
 
-const route = new Router()
+const route = new Router({
+  prefix: '/newest'
+})
 
 /**
- * GET /api/newest
- * Finds the newest _first_ published project
+ * GET /api/newest/release
+ * Finds the newest released project
  */
-route.get('/newest', async (ctx) => {
+route.get('/release', async (ctx) => {
   const projects = await Project.aggregate([
     { $unwind: '$releases' },
     { $match: {
@@ -23,8 +25,30 @@ route.get('/newest', async (ctx) => {
       'releases.date.published': { $exists: true }
     }},
     { $sort: { 'releases.date.published': -1 } },
-    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
-    { $sort: { 'release.date.published': -1 } },
+    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'released': { $first: '$releases.date.published' } } },
+    { $sort: { 'released.date.published': -1 } },
+    { $limit: 10 }
+  ])
+
+  ctx.status = 200
+  ctx.body = { data: projects.map((p) => p.name) }
+
+  return
+})
+
+/**
+ * GET /api/newest/project
+ * Finds the newest _first_ published project
+ */
+route.get('/project', async (ctx) => {
+  const projects = await Project.aggregate([
+    { $unwind: '$releases' },
+    { $match: {
+      'releases._status': 'DEFER',
+      'releases.date.published': { $exists: true }
+    }},
+    { $sort: { 'releases.date.published': 1 } },
+    { $group: { _id: '$_id', 'name': { $first: '$name' } } },
     { $limit: 10 }
   ])
 


### PR DESCRIPTION
Fixes the API endpoint for projects. This should resolve AppCenter banner showing the newest release instead of newest project in AppCenter.

Adds a `/api/newest/release` endpoint to list projects by latest release

This will need an API endpoint change in AppCenter.