### PR TITLE
cache res and filter dups

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "moment": "^2.17.0",
     "mongoose": "^4.7.0",
     "monq": "^0.3.6",
+    "node-cache": "^4.1.1",
     "nodegit": "^0.16.0",
     "nunjucks": "^3.0.0",
     "oauth": "^0.9.14",

--- a/src/houston/controller/api/list.js
+++ b/src/houston/controller/api/list.js
@@ -5,22 +5,31 @@
  * @exports {Object} - Koa router
  */
 
+import Cache from 'node-cache'
 import moment from 'moment'
 import Router from 'koa-router'
 
 import Download from 'lib/database/download'
 import Project from 'lib/database/project'
 
+const cache = new Cache({ stdTTL: 600 })
 const route = new Router({
   prefix: '/newest'
 })
 
 /**
- * GET /api/newest
- * Finds the newest _first_ published project
- * DEPRECATED: 05/06/2017 use /api/newest/project endpoint instead
+ * findReleases
+ * Finds the projects with the newest releases.
+ *
+ * @return {string[]}
  */
-route.get('/', async (ctx) => {
+const findReleases = async () => {
+  const cachedRes = cache.get('findReleases')
+
+  if (cachedRes != null) {
+    return cachedRes
+  }
+
   const projects = await Project.aggregate([
     { $unwind: '$releases' },
     { $match: {
@@ -30,43 +39,28 @@ route.get('/', async (ctx) => {
     { $sort: { 'releases.date.published': 1 } },
     { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
     { $sort: { 'release.date.published': -1 } },
-    { $limit: 10 }
+    { $limit: 5 }
   ])
+  .then((res) => res.map((p) => p.name))
 
-  ctx.status = 200
-  ctx.body = { data: projects.map((p) => p.name) }
-
-  return
-})
+  cache.set('findReleases', projects)
+  return projects
+}
 
 /**
- * GET /api/newest/release
- * Finds the newest released project
+ * findProjects
+ * Finds the newest projects that have been released.
+ *
+ * @return {string[]}
  */
-route.get('/release', async (ctx) => {
-  const projects = await Project.aggregate([
-    { $unwind: '$releases' },
-    { $match: {
-      'releases._status': 'DEFER',
-      'releases.date.published': { $exists: true }
-    }},
-    { $sort: { 'releases.date.published': -1 } },
-    { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
-    { $sort: { 'release.date.published': -1 } },
-    { $limit: 10 }
-  ])
+const findProjects = async () => {
+  const cachedRes = cache.get('findProjects')
 
-  ctx.status = 200
-  ctx.body = { data: projects.map((p) => p.name) }
+  if (cachedRes != null) {
+    return cachedRes
+  }
 
-  return
-})
-
-/**
- * GET /api/newest/project
- * Finds the newest _first_ published project
- */
-route.get('/project', async (ctx) => {
+  const cachedReleases = await findReleases()
   const projects = await Project.aggregate([
     { $unwind: '$releases' },
     { $match: {
@@ -76,23 +70,31 @@ route.get('/project', async (ctx) => {
     { $sort: { 'releases.date.published': 1 } },
     { $group: { _id: '$_id', 'name': { $first: '$name' }, 'release': { $first: '$releases' } } },
     { $sort: { 'release.date.published': -1 } },
-    { $limit: 10 }
+    { $match: { 'name': { $nin: cachedReleases } } },
+    { $limit: 5 }
   ])
+  .then((res) => res.map((p) => p.name))
 
-  ctx.status = 200
-  ctx.body = { data: projects.map((p) => p.name) }
-
-  return
-})
+  cache.set('findProjects', projects)
+  return projects
+}
 
 /**
- * GET /api/newest/downloads
- * Finds the projects with the most downloads in the current day.
+ * findDownloads
+ * Finds the projects with the newest releases.
+ *
+ * @return {string[]}
  */
-route.get('/downloads', async (ctx) => {
+const findDownloads = async () => {
+  const cachedRes = cache.get('findDownloads')
+
+  if (cachedRes != null) {
+    return cachedRes
+  }
+
+  const [cachedReleases, cachedProjects] = await Promise.all([findReleases(), findProjects()])
   const currentDay = moment.utc().get('date')
-
-  const results = await Download.aggregate([
+  const projects = await Download.aggregate([
     { $match: { type: 'month' } },
     { $lookup: {
       from: 'projects',
@@ -107,12 +109,64 @@ route.get('/downloads', async (ctx) => {
       'total': { $sum: '$current.total' }
     }},
     { $sort: { 'count': -1, 'total': -1 } },
-    { $match: { 'name': { $size: 1 } } }, // Avoid deleted projects
-    { $limit: 10 }
+    { $match: { 'name': { $size: 1 }, 'name.0': { $nin: [...cachedReleases, ...cachedProjects] } } }, // Avoid deleted projects
+    { $limit: 5 }
   ])
+  .then((res) => res.map((p) => p.name[0]))
+
+  cache.set('findDownloads', projects)
+  return projects
+}
+
+/**
+ * GET /api/newest/project
+ * Finds the newest _first_ published project
+ */
+route.get('/project', async (ctx) => {
+  const projects = await findReleases()
 
   ctx.status = 200
-  ctx.body = { data: results.map((p) => p.name[0]) }
+  ctx.body = { data: projects }
+
+  return
+})
+
+/**
+ * GET /api/newest
+ * Finds the newest _first_ published project
+ * DEPRECATED: 05/06/2017 use /api/newest/project endpoint instead
+ */
+route.get('/', async (ctx) => {
+  const projects = await findProjects()
+
+  ctx.status = 200
+  ctx.body = { data: projects }
+
+  return
+})
+
+/**
+ * GET /api/newest/release
+ * Finds the newest released project
+ */
+route.get('/release', async (ctx) => {
+  const projects = await findProjects()
+
+  ctx.status = 200
+  ctx.body = { data: projects }
+
+  return
+})
+
+/**
+ * GET /api/newest/downloads
+ * Finds the projects with the most downloads in the current day.
+ */
+route.get('/downloads', async (ctx) => {
+  const projects = await findDownloads()
+
+  ctx.status = 200
+  ctx.body = { data: projects }
 
   return
 })


### PR DESCRIPTION
This caches the responses for all 3 appcenter endpoints. Reduces response time by 400% or so locally.  Lasts 10 minutes. Also filters out projects in other endpoints when responding. It filters in the order of banner > updated > downloads.