### PR TITLE
add endpoint to see total amount of downloads

### DIFF
--- a/src/houston/controller/api/downloads.js
+++ b/src/houston/controller/api/downloads.js
@@ -1,0 +1,105 @@
+/**
+ * houston/controller/api/downloads.js
+ * Shows total download counts
+ *
+ * @exports {Object} - Koa router
+ */
+
+import Cache from 'node-cache'
+import moment from 'moment'
+import Router from 'koa-router'
+
+import Download from 'lib/database/download'
+
+const cache = new Cache({ stdTTL: 600 })
+const route = new Router({
+  prefix: '/downloads'
+})
+
+/**
+ * findTotal
+ * Finds total amount of downloads.
+ *
+ * @return {number}
+ */
+const findTotal = async () => {
+  const cachedRes = cache.get('findTotal')
+
+  if (cachedRes != null) {
+    return cachedRes
+  }
+
+  const downloads = await Download.aggregate([
+    { $match: { type: 'year' } },
+    { $group: { _id: 0, total: { $sum: '$current.total' } } }
+  ])
+
+  if (downloads[0] == null) {
+    return 0
+  }
+
+  const total = downloads[0]['total']
+
+  cache.set('findTotal', total)
+  return total
+}
+
+/**
+ * findDay
+ * Finds total amount of downloads for the current day.
+ *
+ * @return {number}
+ */
+const findDay = async () => {
+  const cachedRes = cache.get('findDay')
+
+  if (cachedRes != null) {
+    return cachedRes
+  }
+
+  const downloads = await Download.aggregate([
+    { $match: { type: 'hour' } },
+    { $group: { _id: 0, total: { $sum: '$current.total' } } }
+  ])
+
+  if (downloads[0] == null) {
+    return 0
+  }
+
+  const total = downloads[0]['total']
+
+  cache.set('findDay', total)
+  return total
+}
+
+/**
+ * GET /api/downloads/total
+ * Returns the amount of downloads that have hit the server.
+ */
+route.get('/total', async (ctx) => {
+  const total = await findTotal()
+
+  ctx.status = 200
+  ctx.body = { data: {
+    total
+  }}
+
+  return
+})
+
+/**
+ * GET /api/downloads/day
+ * Returns the amount of downloads for the current day.
+ */
+route.get('/day', async (ctx) => {
+  const total = await findDay()
+
+  ctx.status = 200
+  ctx.body = { data: {
+    total
+  }}
+
+  return
+})
+
+export default route

--- a/src/houston/controller/api/downloads.js
+++ b/src/houston/controller/api/downloads.js
@@ -6,7 +6,6 @@
  */
 
 import Cache from 'node-cache'
-import moment from 'moment'
 import Router from 'koa-router'
 
 import Download from 'lib/database/download'

--- a/src/houston/controller/api/index.js
+++ b/src/houston/controller/api/index.js
@@ -13,6 +13,7 @@ import { ControllerError } from 'lib/error/controller'
 import { toAPI } from './error'
 import config from 'lib/config'
 
+import downloads from './downloads'
 import list from './list'
 import payment from './payment'
 
@@ -80,6 +81,7 @@ route.use((ctx, next) => {
 })
 
 // Load all api paths here
+route.use(downloads.routes(), downloads.allowedMethods())
 route.use(list.routes(), list.allowedMethods())
 route.use(payment.routes(), payment.allowedMethods())
 

--- a/src/houston/views/agreement.pug
+++ b/src/houston/views/agreement.pug
@@ -4,7 +4,7 @@ block body
   div.grid
     div.two-thirds.scrollbox
       h2 Terms of Service
-      h5 Last updated January 13, 2017
+      h5 Last updated June 26, 2017
       p By accepting the Terms of this agreement you agree to be bound by the following Terms and Conditions of Use. If you do not agree with any these Terms, you are prohibited from making use of this website (the "Service") to distribute your application (the "Software").
       h5 Distribution
       p You agree that you own the rights to redistribute the Software through our Service, including commercial rights if you have marked the Software for monetization.


### PR DESCRIPTION
Adds 2 endpoints to see download numbers.

- `/api/downloads/total` Shows all the downloads that ever hit the repository.
- `/api/downloads/day` Shows the amount of downloads that occured in the current day.
