### PR TITLE
Update the docker file to support building nodejs app

### DIFF
--- a/src/flightcheck/pipes/Liftoff/docker/Dockerfile
+++ b/src/flightcheck/pipes/Liftoff/docker/Dockerfile
@@ -19,6 +19,10 @@ ENV DEBCONF_NOWARNINGS yes
 COPY liftoff_0.1_amd64.deb /tmp/liftoff.deb
 RUN dpkg -i /tmp/liftoff.deb; exit 0
 
+# install latest nodejs
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+
 RUN apt update && apt install -y -f
 
 # removes annoying log message


### PR DESCRIPTION
This PR helps Nodejs and Vala hybrids apps to be built entirely on Docker without resorting to pre building binary. 
see issues:
https://github.com/elementary/houston/issues/530 
https://github.com/elementary/houston/issues/528
https://github.com/harisvsulaiman/pushy/issues/13

Note: This is a widely used Nodejs PPA, even cited in the official docs.
https://github.com/nodesource/distributions