### PR TITLE
chmod everything after unpacking deb file

### DIFF
--- a/src/flightcheck/pipes/Repack/docker/repack.sh
+++ b/src/flightcheck/pipes/Repack/docker/repack.sh
@@ -25,16 +25,39 @@ if [ "$O" == "pack" ] && [ ! -d "$P" ]; then
   exit 1
 fi
 
-# Extracting a package
 if [ "$O" == "extract" ]; then
+  cd $P
+
+  # Extracting a package
   dpkg-deb -x $P $D
   dpkg-deb -e $P $D/DEBIAN
 
   rm $P
+
+  # Creates a list of all the original package permissions for each file
+  touch $D/FILES
+  find $P -exec stat -c "%a;%n" {} \; > $D/FILES
+
+  # Sets everything to an open permission to allow edits without root access
+  chmod -R 777 $D
 fi
 
 if [ "$O" == "pack" ]; then
   cd $P
+
+  # Restores the original package permissions
+  while read l in; do
+    IFS=';' read o f <<< "$l"
+
+    chmod "$o" "$f"
+  done < $P/FILES
+
+  # Remove any extra files that are not part of the package
+  rm $P/FILES
+
+  # And build the package
+  mkdir -p $P/DEBIAN
+  touch $P/DEBIAN/md5sums
   find . -type f ! -regex '.*.hg.*' ! -regex '.*?debian-binary.*' ! -regex '.*?DEBIAN.*' -printf '%P ' | xargs md5sum > $P/DEBIAN/md5sums
   dpkg-deb -b $P $D
 


### PR DESCRIPTION
Updates the extract script to run `chmod 777` on every file after unpacking the `deb` package. This avoids trying to delete root files (from the deb package) as an unprivileged (houston) user. After we are done editing, it goes back and re-runs `chmod` with the original permissions for every file.

Someone with better bash knowledge should look at this for mistakes, as I'm not great at it.

Fixes #508