### PR TITLE
Added basic check for appdata id (fixes #538)

### DIFF
--- a/src/flightcheck/pipes/AppData/index.js
+++ b/src/flightcheck/pipes/AppData/index.js
@@ -30,7 +30,8 @@ export default class AppData extends Pipe {
    */
   tests () {
     return [
-      'AppDataChangelog'
+      'AppDataChangelog',
+      'AppDataId'
     ]
   }
 

--- a/src/flightcheck/pipes/AppData/test/Id.js
+++ b/src/flightcheck/pipes/AppData/test/Id.js
@@ -1,0 +1,43 @@
+/**
+ * flightcheck/pipes/AppData/test/changelog.js
+ * Checks appdata has id key and matches the RDNN
+ * @flow
+ *
+ * @exports {Pipe} - Checks appdata has id key and matches the RDNN
+ */
+
+import Parseable from 'flightcheck/file/parsable'
+import Pipe from 'flightcheck/pipes/pipe'
+
+/**
+ * AppDataChangelog
+ * Checks appdata has id key and matches the RDNN
+ *
+ * @extends Pipe
+ */
+export default class AppDataId extends Pipe {
+
+  /**
+   * code
+   * Checks appdata has id key and matches the RDNN
+   *
+   * @param {Parseable} f - The AppData file
+   * @returns {Void}
+   */
+  async code (f: Parseable) {
+    const file = await f.parse()
+    const expectedId = `${this.pipeline.build.name}.desktop`;
+
+    try {
+      if (!file.component.id) {
+        throw new Error('Missing id');
+      }
+
+      if (file.component.id[0] !== expectedId) {
+        throw new Error(`Id [${file.component.id[0]}] does not match expected RDNN [${expectedId}]`);
+      }
+    } catch (err) {
+      return this.log('warn', 'AppData/test/id.md');
+    }
+  }
+}

--- a/src/flightcheck/pipes/AppData/test/Id.js
+++ b/src/flightcheck/pipes/AppData/test/Id.js
@@ -33,7 +33,7 @@ export default class AppDataId extends Pipe {
         throw new Error('Missing id')
       }
     } catch (err) {
-      return this.log('warn', 'AppData/test/id.md')
+      return this.log('warn', 'AppData/test/id.md', this.pipeline.build.name)
     }
 
     try {
@@ -41,7 +41,7 @@ export default class AppDataId extends Pipe {
         throw new Error(`Id [${file.component.id[0]}] does not match expected RDNN [${expectedId}]`)
       }
     } catch (err) {
-      return this.log('warn', 'AppData/test/id.md')
+      return this.log('warn', 'AppData/test/id.md', this.pipeline.build.name)
     }
   }
 }

--- a/src/flightcheck/pipes/AppData/test/Id.js
+++ b/src/flightcheck/pipes/AppData/test/Id.js
@@ -26,22 +26,22 @@ export default class AppDataId extends Pipe {
    */
   async code (f: Parseable) {
     const file = await f.parse()
-    const expectedId = `${this.pipeline.build.name}.desktop`;
+    const expectedId = `${this.pipeline.build.name}.desktop`
 
     try {
       if (!file.component.id) {
-        throw new Error('Missing id');
+        throw new Error('Missing id')
       }
     } catch (err) {
-      return this.log('warn', 'AppData/test/id.md');
+      return this.log('warn', 'AppData/test/id.md')
     }
 
     try {
       if (file.component.id[0] !== expectedId) {
-        throw new Error(`Id [${file.component.id[0]}] does not match expected RDNN [${expectedId}]`);
+        throw new Error(`Id [${file.component.id[0]}] does not match expected RDNN [${expectedId}]`)
       }
     } catch (err) {
-      return this.log('warn', 'AppData/test/id.md');
+      return this.log('warn', 'AppData/test/id.md')
     }
   }
 }

--- a/src/flightcheck/pipes/AppData/test/Id.js
+++ b/src/flightcheck/pipes/AppData/test/Id.js
@@ -1,5 +1,5 @@
 /**
- * flightcheck/pipes/AppData/test/changelog.js
+ * flightcheck/pipes/AppData/test/Id.js
  * Checks appdata has id key and matches the RDNN
  * @flow
  *
@@ -10,7 +10,7 @@ import Parseable from 'flightcheck/file/parsable'
 import Pipe from 'flightcheck/pipes/pipe'
 
 /**
- * AppDataChangelog
+ * AppDataId
  * Checks appdata has id key and matches the RDNN
  *
  * @extends Pipe
@@ -32,7 +32,11 @@ export default class AppDataId extends Pipe {
       if (!file.component.id) {
         throw new Error('Missing id');
       }
+    } catch (err) {
+      return this.log('warn', 'AppData/test/id.md');
+    }
 
+    try {
       if (file.component.id[0] !== expectedId) {
         throw new Error(`Id [${file.component.id[0]}] does not match expected RDNN [${expectedId}]`);
       }

--- a/src/flightcheck/pipes/AppData/test/Id.js
+++ b/src/flightcheck/pipes/AppData/test/Id.js
@@ -33,7 +33,7 @@ export default class AppDataId extends Pipe {
         throw new Error('Missing id')
       }
     } catch (err) {
-      return this.log('warn', 'AppData/test/id.md', this.pipeline.build.name)
+      return this.log('error', 'AppData/test/id.md', this.pipeline.build.name)
     }
 
     try {
@@ -41,7 +41,7 @@ export default class AppDataId extends Pipe {
         throw new Error(`Id [${file.component.id[0]}] does not match expected RDNN [${expectedId}]`)
       }
     } catch (err) {
-      return this.log('warn', 'AppData/test/id.md', this.pipeline.build.name)
+      return this.log('error', 'AppData/test/id.md', this.pipeline.build.name)
     }
   }
 }

--- a/src/flightcheck/pipes/AppData/test/id.md
+++ b/src/flightcheck/pipes/AppData/test/id.md
@@ -1,6 +1,6 @@
 Missing AppStream id
 
-AppCenter requires the AppStream id to provided and must match you RDNN. Please provide an id for your releases.
+AppCenter requires the AppStream id to provided and must match your RDNN (com.github.username.repo.desktop). Please provide an id and match it to your RDNN.
 
 For more information, please look at the
 [appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/AppData/test/id.md
+++ b/src/flightcheck/pipes/AppData/test/id.md
@@ -1,0 +1,6 @@
+Missing AppStream id
+
+AppCenter requires the AppStream id to provided and must match you RDNN. Please provide an id for your releases.
+
+For more information, please look at the
+[appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/AppData/test/id.md
+++ b/src/flightcheck/pipes/AppData/test/id.md
@@ -1,6 +1,6 @@
-Missing AppStream id
+Missing AppStream ID
 
-AppCenter requires the AppStream id to provided and must match your RDNN (com.github.username.repo.desktop). Please provide an id and match it to your RDNN.
+AppCenter requires the AppStream ID to be set, and it must match your RDNN (`{{ data }}.desktop`).
 
 For more information, please look at the
 [appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/index.js
+++ b/src/flightcheck/pipes/index.js
@@ -7,6 +7,7 @@
 
 export AppData from './AppData'
 export AppDataChangelog from './AppData/test/Changelog'
+export AppDataId from './AppData/test/Id'
 export AppHub from './AppHub'
 export BinTest from './BinTest'
 export Build from './Build'


### PR DESCRIPTION
This test is currently only warning and providing the same message if the id is missing OR the id does not match the RDNN.