### PR TITLE
Add app data developer name test (fixes #536)

### DIFF
--- a/src/flightcheck/pipes/AppData/index.js
+++ b/src/flightcheck/pipes/AppData/index.js
@@ -31,7 +31,8 @@ export default class AppData extends Pipe {
   tests () {
     return [
       'AppDataChangelog',
-      'AppDataId'
+      'AppDataId',
+      'AppDeveloperName'
     ]
   }
 

--- a/src/flightcheck/pipes/AppData/index.js
+++ b/src/flightcheck/pipes/AppData/index.js
@@ -32,7 +32,7 @@ export default class AppData extends Pipe {
     return [
       'AppDataChangelog',
       'AppDataId',
-      'AppDeveloperName'
+      'AppDataDeveloperName'
     ]
   }
 

--- a/src/flightcheck/pipes/AppData/test/DeveloperName.js
+++ b/src/flightcheck/pipes/AppData/test/DeveloperName.js
@@ -1,0 +1,38 @@
+/**
+ * flightcheck/pipes/AppData/test/DeveloperName.js
+ * Checks appdata has developer_name
+ * @flow
+ *
+ * @exports {Pipe} - Checks appdata has developer_name
+ */
+
+import Parseable from 'flightcheck/file/parsable'
+import Pipe from 'flightcheck/pipes/pipe'
+
+/**
+ * AppDataDeveloperName
+ * Checks appdata has developer_name
+ *
+ * @extends Pipe
+ */
+export default class AppDataDeveloperName extends Pipe {
+
+  /**
+   * code
+   * Checks appdata has developer_name
+   *
+   * @param {Parseable} f - The AppData file
+   * @returns {Void}
+   */
+  async code (f: Parseable) {
+    const file = await f.parse()
+
+    try {
+      if (!file.component.developer_name) {
+        throw new Error('Missing developer_name')
+      }
+    } catch (err) {
+      return this.log('error', 'AppData/test/developerName.md')
+    }
+  }
+}

--- a/src/flightcheck/pipes/AppData/test/DeveloperName.js
+++ b/src/flightcheck/pipes/AppData/test/DeveloperName.js
@@ -31,6 +31,10 @@ export default class AppDataDeveloperName extends Pipe {
       if (!file.component.developer_name) {
         throw new Error('Missing developer_name')
       }
+
+      if (file.component.developer_name[0].length == 0) {
+        throw new Error('developer_name is empty')
+      }
     } catch (err) {
       return this.log('error', 'AppData/test/developerName.md')
     }

--- a/src/flightcheck/pipes/AppData/test/DeveloperName.js
+++ b/src/flightcheck/pipes/AppData/test/DeveloperName.js
@@ -32,7 +32,7 @@ export default class AppDataDeveloperName extends Pipe {
         throw new Error('Missing developer_name')
       }
 
-      if (file.component.developer_name[0].length == 0) {
+      if (file.component.developer_name[0].length === 0) {
         throw new Error('developer_name is empty')
       }
     } catch (err) {

--- a/src/flightcheck/pipes/AppData/test/developerName.md
+++ b/src/flightcheck/pipes/AppData/test/developerName.md
@@ -1,0 +1,6 @@
+Missing AppStream Developer Name
+
+AppCenter displays the developer name from the AppStream. Please provide a developer_name.
+
+For more information, please look at the
+[appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/AppData/test/developerName.md
+++ b/src/flightcheck/pipes/AppData/test/developerName.md
@@ -1,6 +1,6 @@
 Missing AppStream Developer Name
 
-AppCenter displays the developer name from the AppStream. Please provide a developer_name.
+AppCenter displays the developer name from the AppStream. Please provide a `developer_name`.
 
 For more information, please look at the
 [appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/index.js
+++ b/src/flightcheck/pipes/index.js
@@ -7,6 +7,7 @@
 
 export AppData from './AppData'
 export AppDataChangelog from './AppData/test/Changelog'
+export AppDataDeveloperName from './AppData/test/DeveloperName'
 export AppDataId from './AppData/test/Id'
 export AppHub from './AppHub'
 export BinTest from './BinTest'


### PR DESCRIPTION
Adds a check to see whether `developer_name` exists in the AppData (fixes #536).

Will throw an error if developer_name doesn't exist or if the element's length is zero.