### PR TITLE
Add appdata project license test (fixes #537)

### DIFF
--- a/src/flightcheck/pipes/AppData/index.js
+++ b/src/flightcheck/pipes/AppData/index.js
@@ -31,7 +31,8 @@ export default class AppData extends Pipe {
   tests () {
     return [
       'AppDataChangelog',
-      'AppDataId'
+      'AppDataId',
+      'AppDataProjectLicense'
     ]
   }
 

--- a/src/flightcheck/pipes/AppData/test/ProjectLicense.js
+++ b/src/flightcheck/pipes/AppData/test/ProjectLicense.js
@@ -32,7 +32,7 @@ export default class AppDataProjectLicense extends Pipe {
         throw new Error('Missing project_license')
       }
 
-      if (file.component.project_license.length == 0) {
+      if (file.component.project_license.length === 0) {
         throw new Error('Empty project_license')
       }
     } catch (err) {

--- a/src/flightcheck/pipes/AppData/test/ProjectLicense.js
+++ b/src/flightcheck/pipes/AppData/test/ProjectLicense.js
@@ -1,0 +1,42 @@
+/**
+ * flightcheck/pipes/AppData/test/ProjectLicense.js
+ * Checks appdata has project_license key
+ * @flow
+ *
+ * @exports {Pipe} - Checks appdata has project_license key
+ */
+
+import Parseable from 'flightcheck/file/parsable'
+import Pipe from 'flightcheck/pipes/pipe'
+
+/**
+ * AppDataProjectLicense
+ * Checks appdata has project_license key
+ *
+ * @extends Pipe
+ */
+export default class AppDataProjectLicense extends Pipe {
+
+  /**
+   * code
+   * Checks appdata has project_license key
+   *
+   * @param {Parseable} f - The AppData file
+   * @returns {Void}
+   */
+  async code (f: Parseable) {
+    const file = await f.parse()
+
+    try {
+      if (!file.component.project_license) {
+        throw new Error('Missing project_license')
+      }
+
+      if (file.component.project_license.length == 0) {
+        throw new Error('Empty project_license')
+      }
+    } catch (err) {
+      return this.log('warn', 'AppData/test/projectLicense.md')
+    }
+  }
+}

--- a/src/flightcheck/pipes/AppData/test/projectLicense.md
+++ b/src/flightcheck/pipes/AppData/test/projectLicense.md
@@ -1,6 +1,6 @@
-Missing AppStream project_license
+Missing AppStream license
 
-AppStream should contain a project_license to inform users in the AppCenter. For examples of licenses, please see [https://choosealicense.com/](https://choosealicense.com/).
+AppStream should contain a `project_license` to inform users in the AppCenter. For examples of licenses, please see [https://choosealicense.com/](https://choosealicense.com/).
 
 For more information, please look at the
 [appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/AppData/test/projectLicense.md
+++ b/src/flightcheck/pipes/AppData/test/projectLicense.md
@@ -1,0 +1,6 @@
+Missing AppStream project_license
+
+AppStream should contain a project_license to inform users in the AppCenter. Please provide a project_license for release. For examples of licenses, please look at [https://choosealicense.com/](https://choosealicense.com/).
+
+For more information, please look at the
+[appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/AppData/test/projectLicense.md
+++ b/src/flightcheck/pipes/AppData/test/projectLicense.md
@@ -1,6 +1,6 @@
 Missing AppStream project_license
 
-AppStream should contain a project_license to inform users in the AppCenter. Please provide a project_license for release. For examples of licenses, please look at [https://choosealicense.com/](https://choosealicense.com/).
+AppStream should contain a project_license to inform users in the AppCenter. For examples of licenses, please see [https://choosealicense.com/](https://choosealicense.com/).
 
 For more information, please look at the
 [appstream documentation](https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html).

--- a/src/flightcheck/pipes/index.js
+++ b/src/flightcheck/pipes/index.js
@@ -7,6 +7,7 @@
 
 export AppData from './AppData'
 export AppDataChangelog from './AppData/test/Changelog'
+export AppDataProjectLicense from './AppData/test/ProjectLicense'
 export AppDataId from './AppData/test/Id'
 export AppHub from './AppHub'
 export BinTest from './BinTest'


### PR DESCRIPTION
Checks for the `project_license` element (fixes #537).

Warns the user if it is missing or empty.