### PR TITLE
update needed github apps logic

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -12,8 +12,8 @@ module.exports.github = {
   client: '78zx9c4vb8xc4v5647ar',
   secret: '4ra56dsv489asd4r56b456a489sd7ft89a75s4b8',
 
-  // GitHub integration https://developer.github.com/early-access/integrations
-  integration: {
+  // GitHub integration https://developer.github.com/apps/
+  app: {
     id: 11,
 
     // Full path to GitHub integration private key.

--- a/src/houston/controller/hook/github.js
+++ b/src/houston/controller/hook/github.js
@@ -135,7 +135,7 @@ route.all('/', (ctx, next) => {
  * Checks for accurate webhook secret
  */
 route.all('/', async (ctx, next) => {
-  if (config.github.integration.secret == null || !config.github.integration.secret) {
+  if (config.github.app.secret == null || !config.github.app.secret) {
     log.warn('Using insecure settings. Please setup integration webhook secret')
     return next()
   }
@@ -149,7 +149,7 @@ route.all('/', async (ctx, next) => {
   }
 
   const hash = crypto
-  .createHmac('sha1', config.github.integration.secret)
+  .createHmac('sha1', config.github.app.secret)
   .update(ctx.request.rawBody)
   .digest('hex')
 
@@ -185,7 +185,7 @@ route.post('/', (ctx, next) => {
  * Handles the creation of new installations
  */
 route.post('/', async (ctx, next) => {
-  if (ctx.request.header['x-github-event'] !== 'integration_installation') return next()
+  if (ctx.request.header['x-github-event'] !== 'installation') return next()
 
   if (typeof ctx.request.body !== 'object') {
     ctx.status = 400
@@ -256,7 +256,7 @@ route.post('/', async (ctx, next) => {
  * Handles adding and removing of installations
  */
 route.post('/', async (ctx, next) => {
-  if (ctx.request.header['x-github-event'] !== 'integration_installation_repositories') return next()
+  if (ctx.request.header['x-github-event'] !== 'installation_repositories') return next()
 
   if (typeof ctx.request.body !== 'object') {
     ctx.status = 400

--- a/src/service/github.js
+++ b/src/service/github.js
@@ -216,7 +216,7 @@ export async function generateJWT (exp: Date = moment().add(1, 'minutes').toDate
   const key = await new Promise((resolve, reject) => {
     log.debug('Reading integration key')
 
-    fs.readFile(config.github.integration.key, (err, data) => {
+    fs.readFile(config.github.app.key, (err, data) => {
       if (err) return reject(err)
       return resolve(data)
     })
@@ -226,7 +226,7 @@ export async function generateJWT (exp: Date = moment().add(1, 'minutes').toDate
   const payload = {
     iat: Math.floor(Date.now() / 1000),
     exp: Math.floor(exp.getTime() / 1000),
-    iss: config.github.integration.id
+    iss: config.github.app.id
   }
 
   return new Promise((resolve, reject) => {
@@ -333,12 +333,9 @@ export async function getReposForUser (user: User): Promise<Array<Object>> {
   if (user.github != null && user.github.cache != null) {
     if (moment().diff(user.github.cache) <= GITHUB_CACHE_TIME) {
       if (user.github.projects != null && user.github.projects.length > 0) {
-        // DEPRECATED let the old object storage format rest in peace.
-        if (typeof user.github.projects[0] === 'number') {
-          return Project.find({
-            'github.id': { $in: user.github.projects }
-          })
-        }
+        return Project.find({
+          'github.id': { $in: user.github.projects }
+        })
       }
     }
   }

--- a/test/fixtures/config.js
+++ b/test/fixtures/config.js
@@ -12,7 +12,7 @@ module.exports.env = 'test'
 module.exports.github = {
   client: '123456789yoloswagomg',
   secret: 'butwait%20letmetakeaselfeshutthefrackup!',
-  integration: {
+  app: {
     id: 11,
     key: path.resolve(__dirname, 'github', 'private.pem'),
     secret: 'asecretwebhookkey'

--- a/test/service/github.js
+++ b/test/service/github.js
@@ -75,8 +75,8 @@ test('Can generate an accurate JWT', async (t) => {
 
   t.is(typeof three, 'object')
   t.is(typeof four, 'object')
-  t.is(three.iss, config.github.integration.id)
-  t.is(four.iss, config.github.integration.id)
+  t.is(three.iss, config.github.app.id)
+  t.is(four.iss, config.github.app.id)
   t.true(three.iat < new Date().getTime())
   t.true(four.iat < new Date().getTime())
   t.true(three.exp > Math.floor(Date.now() / 1000))


### PR DESCRIPTION
Fixes #513 

Luckely we don't use most of the `app` endpoints, but the `installation` endpoints, so only the two github hook names needed changing. Updated the `config.js` file to avoid confusion in new setups.