### PR TITLE
remove project stripe key check on payment

### DIFF
--- a/src/houston/controller/api/payment.js
+++ b/src/houston/controller/api/payment.js
@@ -99,14 +99,6 @@ const validatePayload = (ControllerError, project, data) => {
     email: null
   }
 
-  if (data.key == null || data.key === '') {
-    errors.push(ControllerError(400, 'key', 'Missing Key'))
-  } else if (data.key.startsWith('pk_') === false) {
-    errors.push(ControllerError(400, 'key', 'Invalid Key'))
-  } else if (data.key !== project.stripe.public) {
-    errors.push(ControllerError(400, 'key', 'The given key does not match the one on file'))
-  }
-
   if (data.token == null || data.token === '') {
     errors.push(ControllerError(400, 'token', 'Missing Token'))
   } else if (data.token.startsWith('tok_') === false) {

--- a/test/houston/controller/api/payment.js
+++ b/test/houston/controller/api/payment.js
@@ -120,58 +120,6 @@ test('Returns key with enabled Project', async (t) => {
   .expect((res) => (res.body.key === 'testingkey'))
 })
 
-test('Returns 400 with missing Project key', async (t) => {
-  await Project.remove({ name: 'com.testing.apipayments.3' })
-
-  await Project.create({
-    name: 'com.testing.apipayments.3',
-    repo: 'https://testing.com/apipayments/3.git',
-    'github.id': 448912,
-    'stripe.enabled': true,
-    'stripe.id': 'acct_123',
-    'stripe.access': 'tok_123',
-    'stripe.public': 'pk_123'
-  })
-
-  return request(server.listen())
-  .post('/api/payment/com.testing.apipayments.3')
-  .set('Accept', 'application/vnd.api+json')
-  .set('Content-Type', 'application/vnd.api+json')
-  .send({
-    data: Object.assign({}, GOLD_REQ, {
-      key: null
-    })
-  })
-  .expect(400)
-  .expect((res) => containsError(res, 'key'))
-})
-
-test('Returns 400 with incorrect Project key', async (t) => {
-  await Project.remove({ name: 'com.testing.apipayments.4' })
-
-  await Project.create({
-    name: 'com.testing.apipayments.4',
-    repo: 'https://testing.com/apipayments/4.git',
-    'github.id': 791567,
-    'stripe.enabled': true,
-    'stripe.id': 'acct_123',
-    'stripe.access': 'tok_123',
-    'stripe.public': 'pk_123'
-  })
-
-  return request(server.listen())
-  .post('/api/payment/com.testing.apipayments.4')
-  .set('Accept', 'application/vnd.api+json')
-  .set('Content-Type', 'application/vnd.api+json')
-  .send({
-    data: Object.assign({}, GOLD_REQ, {
-      key: 'thisisinvalidkey'
-    })
-  })
-  .expect(400)
-  .expect((res) => containsError(res, 'key'))
-})
-
 test('Returns 400 with missing Project token', async (t) => {
   await Project.remove({ name: 'com.testing.apipayments.5' })
 


### PR DESCRIPTION
Removes the project's public stripe key check on payment. This requires no changes on AppCenter, and should help in some instances where a developer changes the application's stripe account. Right now that would cause a mismatch error to some users when trying to charge. Now it wont.