### PR TITLE
Use cheerio for parsing appstream file

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-register": "^6.18.0",
     "bluebird": "^3.4.6",
+    "cheerio": "^1.0.0-rc.2",
     "co": "^4.6.0",
     "commander": "^2.9.0",
     "css-loader": "^0.26.0",


### PR DESCRIPTION
Use `cheerio` for parsing the appstream file because I use it in v2 and it works well...

Fixes reordering appstream data when saving a stripe key.