### PR TITLE
Add a shadow to the appcenter icon

### DIFF
--- a/src/houston/public/styles/index.css
+++ b/src/houston/public/styles/index.css
@@ -347,6 +347,7 @@ section.tools .banner p.split span {
 section.tools .banner svg {
     height: 46px;
     vertical-align: bottom;
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.3));
 }
 
 section.tools .banner .fa {


### PR DESCRIPTION
This adds a shadow to the AppCenter icon that's in the GitHub card under the "Workflow" section