### PR TITLE
Replace Dazzzle with Champlain

### DIFF
--- a/src/houston/views/index.pug
+++ b/src/houston/views/index.pug
@@ -149,8 +149,8 @@ block body
         p: a(href='http://valadoc.org/granite/Granite.Services.ContractorProxy', target='_blank').read-more System Actions
       div.third
         strong UI & Drawing
-        p: a(href='https://valadoc.org/libdazzle-1.0/Dazzle.html', target='_blank').read-more Dazzle
-        p: a(href='http://valadoc.org/granite/Granite', target='_blank').read-more Granite
+        p: a(href='https://valadoc.org/champlain-0.12/Champlain.html', target='_blank').read-more Maps
+        p: a(href='https://valadoc.org/granite/Granite.html', target='_blank').read-more Granite
         p: a(href='https://valadoc.org/gtk+-3.0/Gtk.html', target='_blank').read-more Gtk+
         p: a(href='https://valadoc.org/sdl/SDL.html', target='_blank').read-more SDL
 


### PR DESCRIPTION
At Corentin's suggestion, replaces Dazzle with the maps lib

also update Granite link while we're here