### PR TITLE
Update a few Dockerfiles to use the new loki stable tag

### DIFF
--- a/src/worker/task/appstream/validate/Dockerfile
+++ b/src/worker/task/appstream/validate/Dockerfile
@@ -1,11 +1,9 @@
 # Houston appdata docker file
 # Builds an ubuntu base with appstreamcli for validating appstream files
 #
-# Version: 1.0.3
+# Version: 1.0.4
 
-FROM elementary/docker:loki
-
-MAINTAINER elementary
+FROM elementary/docker:loki-stable
 
 # Install liftoff
 ENV DEBIAN_FRONTEND noninteractive

--- a/src/worker/task/desktop/validate/Dockerfile
+++ b/src/worker/task/desktop/validate/Dockerfile
@@ -1,11 +1,9 @@
 # Houston desktop validate docker file
 # Builds an ubuntu base with desktop-file-utils for validating desktop files
 #
-# Version: 1.0.2
+# Version: 1.0.3
 
-FROM elementary/docker:loki
-
-MAINTAINER elementary
+FROM elementary/docker:loki-stable
 
 # Install liftoff
 ENV DEBIAN_FRONTEND noninteractive

--- a/src/worker/task/extract/deb/Dockerfile
+++ b/src/worker/task/extract/deb/Dockerfile
@@ -1,11 +1,9 @@
 # Houston extract deb docker file
 # Extracts a debian package to editable files
 #
-# Version: 1.0.1
+# Version: 1.0.2
 
-FROM elementary/docker:loki
-
-MAINTAINER elementary
+FROM elementary/docker:loki-stable
 
 # Install liftoff
 ENV DEBIAN_FRONTEND noninteractive

--- a/src/worker/task/pack/deb/Dockerfile
+++ b/src/worker/task/pack/deb/Dockerfile
@@ -1,11 +1,9 @@
 # Houston pack deb docker file
 # Packs a debian package from extracted files
 #
-# Version: 1.0.1
+# Version: 1.0.2
 
-FROM elementary/docker:loki
-
-MAINTAINER elementary
+FROM elementary/docker:loki-stable
 
 # Install liftoff
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
With the recent updates on elementary/docker the old non qualified tags (loki, juno) have been removed. I'm not sure where houston builds docker images based on these files, but basing them on non existing images is going to failed no matter the location.

This is probably the cause for issues such as #751.

I have verified these can be build, but not function as they are part of a pipline that I do not have setup.