### PR TITLE
Index: do the least to point to the new dashboard

### DIFF
--- a/src/houston/views/index.pug
+++ b/src/houston/views/index.pug
@@ -15,11 +15,8 @@ block body
       div.whole
         img(src='https://elementary.io/images/icons/apps/128/system-software-install.svg', alt='AppCenter icon')
         h1 Publish on AppCenter
-        h4 An open, pay-what-you-want app store for indie developers
-        if user
-          a(href='/dashboard').button.suggested-action Welcome Back
-        else
-          a(href='/dashboard').button.suggested-action Log In with GitHub
+        h4 The open, pay-what-you-want app store from elementary
+        a(href='https://github.com/elementary/appcenter-reviews').button.suggested-action Submit an App
       div.half
 
   section.docs

--- a/src/houston/views/layout/main.pug
+++ b/src/houston/views/layout/main.pug
@@ -83,10 +83,6 @@ html
               li: img(src= user.avatar).avatar
 
     div#content-container
-      div.alert.info
-        h3 An <a href="https://github.com/elementary/appcenter-dashboard" target="_blank">all-new AppCenter Dashboard</a> is coming for elementary OS 6
-        p Faster, more reliable, and built entirely around Flatpak. In the meantime, app reviews for elementary OS 5.1 may take longer than usual.
-
       block body
 
     footer


### PR DESCRIPTION
Untested as I'm struggling to get a dev environment set up, but _should_ do the absolute least to get rid of the login button. Does **not** handle the actual dashboard routing yet, but that could be a follow-up.